### PR TITLE
Travis for clang 3.8 + various updates/fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,6 @@ script:
     - ./scripts/reconfigure_script
     - mkdir build
     - cd build
-    - ../configure CXXFLAGS="-fopenmp -msse4.2 -O3 -std=c++11" LIBS="-fopenmp -lmpfr -lgmp" --enable-precision=single --enable-simd=SSE4 --enable-comms=none
-    - cat config.log
+    - ../configure CXXFLAGS="-msse4.2 -O3 -std=c++11" LIBS="-lmpfr -lgmp" --enable-precision=single --enable-simd=SSE4 --enable-comms=none
     - make -j4
-    - ./benchmarks/Benchmark_dwf --threads 2
+    - ./benchmarks/Benchmark_dwf --threads 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,5 +75,6 @@ script:
     - mkdir build
     - cd build
     - ../configure CXXFLAGS="-fopenmp -msse4.2 -O3 -std=c++11" LIBS="-fopenmp -lmpfr -lgmp" --enable-precision=single --enable-simd=SSE4 --enable-comms=none
+    - cat config.log
     - make -j4
     - ./benchmarks/Benchmark_dwf --threads 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,19 +38,6 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-            - libmpfr-dev
-            - libgmp-dev
-            - libmpc-dev
-            - binutils-dev
-      env: VERSION=-3.6
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
@@ -59,6 +46,19 @@ matrix:
             - libmpc-dev
             - binutils-dev
       env: VERSION=-3.7
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages:
+            - clang-3.8
+            - libmpfr-dev
+            - libgmp-dev
+            - libmpc-dev
+            - binutils-dev
+      env: VERSION=-3.8
       
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
@@ -74,6 +74,6 @@ script:
     - ./scripts/reconfigure_script
     - mkdir build
     - cd build
-    - ../configure CXXFLAGS="-msse4.2 -O3 -std=c++11" LIBS="-lmpfr -lgmp" --enable-precision=single --enable-simd=SSE4 --enable-comms=none
+    - ../configure CXXFLAGS="-fopenmp -msse4.2 -O3 -std=c++11" LIBS="-fopenmp -lmpfr -lgmp" --enable-precision=single --enable-simd=SSE4 --enable-comms=none
     - make -j4
-    - ./benchmarks/Benchmark_dwf --threads 1
+    - ./benchmarks/Benchmark_dwf --threads 2

--- a/lib/Init.cc
+++ b/lib/Init.cc
@@ -189,7 +189,8 @@ void Grid_init(int *argc,char ***argv)
     std::cout<<GridLogMessage<<"--mpi n.n.n.n   : default MPI decomposition"<<std::endl;    
     std::cout<<GridLogMessage<<"--omp n         : default number of OMP threads"<<std::endl;    
     std::cout<<GridLogMessage<<"--grid n.n.n.n  : default Grid size"<<std::endl;    
-    std::cout<<GridLogMessage<<"--log list      : comma separted list of streams from Error,Warning,Message,Performance,Iterative,Integrator,Debug"<<std::endl;    
+    std::cout<<GridLogMessage<<"--log list      : comma separted list of streams from Error,Warning,Message,Performance,Iterative,Integrator,Debug"<<std::endl;
+    exit(EXIT_SUCCESS);
   }
 
   if( GridCmdOptionExists(*argv,*argv+*argc,"--log") ){

--- a/lib/algorithms/iterative/ConjugateGradient.h
+++ b/lib/algorithms/iterative/ConjugateGradient.h
@@ -84,7 +84,7 @@ public:
 	return;
       }
       
-      std::cout<<GridLogIterative << std::setprecision(4)<< "ConjugateGradient: k=0 residual "<<cp<<" rsq"<<rsq<<std::endl;
+      std::cout<<GridLogIterative << std::setprecision(4)<< "ConjugateGradient: k=0 residual "<<cp<<" target "<<rsq<<std::endl;
 
       GridStopWatch LinalgTimer;
       GridStopWatch MatrixTimer;
@@ -115,7 +115,7 @@ public:
 	p  = p*b+r;
 	  
 	LinalgTimer.Stop();
-	std::cout<<GridLogIterative<<"ConjugateGradient: Iteration " <<k<<" residual "<<cp<< " target"<< rsq<<std::endl;
+	std::cout<<GridLogIterative<<"ConjugateGradient: Iteration " <<k<<" residual "<<cp<< " target "<< rsq<<std::endl;
 	
 	// Stopping condition
 	if ( cp <= rsq ) { 
@@ -132,9 +132,9 @@ public:
 
 	  std::cout<<GridLogMessage<<"ConjugateGradient: Converged on iteration " <<k
 		   <<" computed residual "<<sqrt(cp/ssq)
-		   <<" true residual     "<<true_residual
+		   <<" true residual "    <<true_residual
 		   <<" target "<<Tolerance<<std::endl;
-	  std::cout<<GridLogMessage<<" Time elapsed: Total "<< SolverTimer.Elapsed() << " Matrix  "<<MatrixTimer.Elapsed() << " Linalg "<<LinalgTimer.Elapsed();
+	  std::cout<<GridLogMessage<<"Time elapsed: Total "<< SolverTimer.Elapsed() << " Matrix  "<<MatrixTimer.Elapsed() << " Linalg "<<LinalgTimer.Elapsed();
 	  std::cout<<std::endl;
 	  
 	  assert(true_residual/Tolerance < 1000.0);

--- a/lib/algorithms/iterative/SchurRedBlack.h
+++ b/lib/algorithms/iterative/SchurRedBlack.h
@@ -102,7 +102,9 @@ namespace Grid {
 
       pickCheckerboard(Even,src_e,in);
       pickCheckerboard(Odd ,src_o,in);
-
+      pickCheckerboard(Even,sol_e,out);
+      pickCheckerboard(Odd ,sol_o,out);
+    
       /////////////////////////////////////////////////////
       // src_o = Mdag * (source_o - Moe MeeInv source_e)
       /////////////////////////////////////////////////////

--- a/lib/lattice/Lattice_reduction.h
+++ b/lib/lattice/Lattice_reduction.h
@@ -152,7 +152,7 @@ template<class vobj> inline void sliceSum(const Lattice<vobj> &Data,std::vector<
   assert(grid!=NULL);
 
   // FIXME
-  std::cout<<GridLogMessage<<"WARNING ! SliceSum is unthreaded "<<grid->SumArraySize()<<" threads "<<std::endl;
+  // std::cout<<GridLogMessage<<"WARNING ! SliceSum is unthreaded "<<grid->SumArraySize()<<" threads "<<std::endl;
 
   const int    Nd = grid->_ndimension;
   const int Nsimd = grid->Nsimd();

--- a/lib/qcd/spin/Dirac.cc
+++ b/lib/qcd/spin/Dirac.cc
@@ -60,6 +60,31 @@ namespace Grid {
       "-Gamma5  ",
       "         "
     };
+    
+    SpinMatrix makeGammaProd(const unsigned int i)
+    {
+      SpinMatrix g;
+      
+      g = 1.;
+      if (i & 0x1)
+      {
+        g = g*Gamma(Gamma::GammaMatrix::GammaX);
+      }
+      if (i & 0x2)
+      {
+        g = g*Gamma(Gamma::GammaMatrix::GammaY);
+      }
+      if (i & 0x4)
+      {
+        g = g*Gamma(Gamma::GammaMatrix::GammaZ);
+      }
+      if (i & 0x8)
+      {
+        g = g*Gamma(Gamma::GammaMatrix::GammaT);
+      }
+      
+      return g;
+    }
 
     //    void sprojMul( vHalfSpinColourVector &out,vColourMatrix &u, vSpinColourVector &in){
     //      vHalfSpinColourVector hspin;

--- a/lib/qcd/spin/Dirac.h
+++ b/lib/qcd/spin/Dirac.h
@@ -82,7 +82,10 @@ namespace QCD {
     GammaMatrix _g;
 
   };
-
+  
+    // Make gamma products (Chroma convention)
+    SpinMatrix makeGammaProd(const unsigned int i);
+    
     /* Gx
      *  0 0  0  i    
      *  0 0  i  0    

--- a/lib/serialisation/BaseIO.h
+++ b/lib/serialisation/BaseIO.h
@@ -49,6 +49,24 @@ namespace Grid {
     return v;
   }
   
+  // output to streams for vectors
+  template < class T >
+  inline std::ostream & operator<<(std::ostream &os, const std::vector<T> &v)
+  {
+    os << "[";
+    for (auto &x: v)
+    {
+      os << x << " ";
+    }
+    if (v.size() > 0)
+    {
+      os << "\b";
+    }
+    os << "]";
+    
+    return os;
+  }
+  
   class Serializable {};
   
   // static polymorphism implemented using CRTP idiom
@@ -152,23 +170,6 @@ namespace Grid {
   inline void read(Reader<T> &r, const std::string &s, U &output)
   {
     r.read(s, output);
-  }
-  
-  template < class T >
-  inline std::ostream& operator << (std::ostream& os, const std::vector<T>& v)
-  {
-    os << "[";
-    for (auto &x: v)
-    {
-      os << x << " ";
-    }
-    if (v.size() > 0)
-    {
-      os << "\b";
-    }
-    os << "]";
-    
-    return os;
   }
   
   // Writer template implementation ////////////////////////////////////////////


### PR DESCRIPTION
I updated Travis for clang 3.8. I deactivated OpenMP it does not work with Travis VM (some missing OpenMP library). I guess we are using Travis just to check if the compilation is producing something meaningful so that's ok. The real OpenMP test can be done using your builds on Cori.

Just a small comment: when you receive a pull request where you wish something to be discussed or modified, you can just let it open and not merge it until you are fully satisfied with it. Like that everything can be settled in one request. Any additional commit from the person requesting will be automatically added to the request.