### PR TITLE
Removed write to stdout in constructor for MPI CartesianCommunicator

### DIFF
--- a/lib/communicator/Communicator_mpi.cc
+++ b/lib/communicator/Communicator_mpi.cc
@@ -53,7 +53,6 @@ CartesianCommunicator::CartesianCommunicator(const std::vector<int> &processors)
   _Nprocessors=1;
   _processors = processors;
   _processor_coor.resize(_ndimension);
-  std::cout << processors << std::endl;
   
   MPI_Cart_create(MPI_COMM_WORLD, _ndimension,&_processors[0],&periodic[0],1,&communicator);
   MPI_Comm_rank(communicator,&_processor);


### PR DESCRIPTION
The constructor for the MPI CartesianCommunicator currently writes the processor layout vector to stdout without context, polluting the output of the benchmarks. I assume this was previously used for debugging purposes and have therefore removed it.