### PR TITLE
Bug/install-Config-h

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -31,5 +31,4 @@ fftw_DATA = libfftw3.a
 # Include files
 #
 otherincludedir = $(includedir)/Grid
-nobase_otherinclude_HEADERS =$(HFILES) $(EFILES) fftw3.h Config.h
-
+nobase_otherinclude_HEADERS =$(HFILES) $(EFILES) fftw3.h


### PR DESCRIPTION
From `scripts/filelist`: 
```
HFILES="$HFILES Config.h"
```

From `lib/Makefile.am`: 
```
nobase_otherinclude_HEADERS =$(HFILES) $(EFILES) fftw3.h Config.h
```

Since `nobase_otherinclude_HEADERS` lists `Config.h` twice it trys to install it twice. The second time it fails and raises the error:
```
/usr/bin/install: will not overwrite just-created `/path/to/Config.h' with `Config.h'
```

Removing the duplicate definition in `lib/Makefile.am` fixes this.