### PR TITLE
Set imaginary part of stochastic QED field to zero after FFT into pos…

### DIFF
--- a/lib/qcd/action/gauge/Photon.h
+++ b/lib/qcd/action/gauge/Photon.h
@@ -173,7 +173,7 @@ namespace QCD{
     }
     fft.FFT_all_dim(out, aTilde, FFT::backward);
 
-    out = 0.5*(out + conjugate(out));
+    out = real(out);
   }
 //  template<class Gimpl>
 //  void Photon<Gimpl>::FeynmanGaugeMomentumSpacePropagator_L(GaugeField &out,

--- a/lib/qcd/action/gauge/Photon.h
+++ b/lib/qcd/action/gauge/Photon.h
@@ -172,6 +172,8 @@ namespace QCD{
       pokeLorentz(aTilde, r, mu);
     }
     fft.FFT_all_dim(out, aTilde, FFT::backward);
+
+    out = 0.5*(out + conjugate(out));
   }
 //  template<class Gimpl>
 //  void Photon<Gimpl>::FeynmanGaugeMomentumSpacePropagator_L(GaugeField &out,


### PR DESCRIPTION
Set imaginary part of the position-space stochastic QED field to zero using "out = 0.5*(out + conjugate(out))", because A_\mu(x) should be a real vector field.