### PR TITLE
Fix misleading message: "doxygen-pdf requires doxygen-pdf"

### DIFF
--- a/m4/ax_prog_doxygen.m4
+++ b/m4/ax_prog_doxygen.m4
@@ -316,7 +316,7 @@ AC_DEFUN([DX_TEST_FEATURE], [test "$DX_FLAG_$1" = 1])
 AC_DEFUN([DX_CHECK_DEPEND], [
 test "$DX_FLAG_$1" = "$2" \
 || AC_MSG_ERROR([doxygen-DX_CURRENT_FEATURE ifelse([$2], 1,
-                            requires, contradicts) doxygen-DX_CURRENT_FEATURE])
+                            requires, contradicts) doxygen-$1])
 ])
 
 # DX_CLEAR_DEPEND(FEATURE, REQUIRED_FEATURE, REQUIRED_STATE)


### PR DESCRIPTION
Currently if you `../configure --enable-doxygen-pdf` without `--enable-doxygen-doc`, you get the error message "`doxygen-pdf requires doxygen-pdf`", which is not helpful. I believe this change fixes it.