### PR TITLE
Fix for 'using namespace' in lib/qcd/utils/GaugeFix.h

### DIFF
--- a/lib/qcd/utils/GaugeFix.h
+++ b/lib/qcd/utils/GaugeFix.h
@@ -26,12 +26,12 @@ Author: Peter Boyle <paboyle@ph.ed.ac.uk>
     /*  END LEGAL */
 //#include <Grid/Grid.h>
 
-using namespace Grid;
-using namespace Grid::QCD;
+namespace Grid {
+namespace QCD {
 
 template <class Gimpl> 
 class FourierAcceleratedGaugeFixer  : public Gimpl {
-  public:
+ public:
   INHERIT_GIMPL_TYPES(Gimpl);
 
   typedef typename Gimpl::GaugeLinkField GaugeMat;
@@ -186,3 +186,5 @@ class FourierAcceleratedGaugeFixer  : public Gimpl {
   }  
 };
 
+}
+}


### PR DESCRIPTION
The 'using namespace Grid' and 'using namespace Grid::QCD' directives are in GaugeFix.h are causing namespace collisions when Grid is used in CPS. To fix this I have moved FourierAcceleratedGaugeFixer into the Grid::QCD namespace and removed the 'using' directives.


