### PR TITLE
Declaring virtual functions as pure virtual functions.

### DIFF
--- a/lib/algorithms/iterative/ImplicitlyRestartedLanczos.h
+++ b/lib/algorithms/iterative/ImplicitlyRestartedLanczos.h
@@ -168,8 +168,8 @@ void basisDeflate(const std::vector<Field> &_v,const std::vector<RealD>& eval,co
 template<class Field> class ImplicitlyRestartedLanczosTester 
 {
  public:
-  virtual int TestConvergence(int j,RealD resid,Field &evec, RealD &eval,RealD evalMaxApprox);
-  virtual int ReconstructEval(int j,RealD resid,Field &evec, RealD &eval,RealD evalMaxApprox);
+  virtual int TestConvergence(int j,RealD resid,Field &evec, RealD &eval,RealD evalMaxApprox)=0;
+  virtual int ReconstructEval(int j,RealD resid,Field &evec, RealD &eval,RealD evalMaxApprox)=0;
 };
 
 enum IRLdiagonalisation { 


### PR DESCRIPTION
These virtual functions must be pure virtual functions when using the Intel 2018 compiler. Possibly other compilers too, though Clang doesn't care.