### PR TITLE
bug fix in sequential insertion of conserved vector current

### DIFF
--- a/lib/qcd/action/fermion/WilsonFermion.cc
+++ b/lib/qcd/action/fermion/WilsonFermion.cc
@@ -395,7 +395,8 @@ void WilsonFermion<Impl>::SeqConservedCurrent(PropagatorField &q_in,
     Lattice<iSinglet<Simd>> ph(_grid), coor(_grid);
     Complex i(0.0,1.0);
     PropagatorField tmpFwd(_grid), tmpBwd(_grid), tmp(_grid);
-    int tshift = (mu == Tp) ? 1 : 0;
+    unsigned int tshift = (mu == Tp) ? 1 : 0;
+    unsigned int LLt    = GridDefaultLatt()[Tp];
 
     // Momentum projection
     ph = zero;
@@ -434,6 +435,11 @@ void WilsonFermion<Impl>::SeqConservedCurrent(PropagatorField &q_in,
         // Repeat for backward direction.
         t_mask     = ((coords._odata[sU] >= (tmin + tshift)) && 
                       (coords._odata[sU] <= (tmax + tshift)));
+
+	//if tmax = LLt-1 (last timeslice) include timeslice 0 if the time is shifted (mu=3)	
+	unsigned int t0 = 0;
+	if((tmax==LLt-1) && (tshift==1)) t_mask = (t_mask || (coords._odata[sU] == t0 ));
+
         timeSlices = Reduce(t_mask);
 
         if (timeSlices > 0)

--- a/lib/qcd/action/fermion/WilsonFermion5D.cc
+++ b/lib/qcd/action/fermion/WilsonFermion5D.cc
@@ -794,8 +794,9 @@ void WilsonFermion5D<Impl>::SeqConservedCurrent(PropagatorField &q_in,
     PropagatorField tmpFwd(FermionGrid()), tmpBwd(FermionGrid()),
                     tmp(FermionGrid());
     Complex i(0.0, 1.0);
-    int tshift = (mu == Tp) ? 1 : 0;
+    unsigned int tshift = (mu == Tp) ? 1 : 0;
     unsigned int LLs = q_in._grid->_rdimensions[0];
+    unsigned int LLt    = GridDefaultLatt()[Tp];
 
     // Momentum projection.
     ph = zero;
@@ -842,6 +843,11 @@ void WilsonFermion5D<Impl>::SeqConservedCurrent(PropagatorField &q_in,
         // Repeat for backward direction.
         t_mask     = ((coords._odata[sU] >= (tmin + tshift)) && 
                       (coords._odata[sU] <= (tmax + tshift)));
+
+	//if tmax = LLt-1 (last timeslice) include timeslice 0 if the time is shifted (mu=3)	
+	unsigned int t0 = 0;
+	if((tmax==LLt-1) && (tshift==1)) t_mask = (t_mask || (coords._odata[sU] == t0 ));
+
         timeSlices = Reduce(t_mask);
 
         if (timeSlices > 0)


### PR DESCRIPTION
when inserting the conserved current V3 (temporal direction) on the last timeslice of the lattice the resulting sequential source was wrong