### PR TITLE
Fix DminusDag bug where dagger wasn't being taken fully.

### DIFF
--- a/lib/qcd/action/fermion/CayleyFermion5D.cc
+++ b/lib/qcd/action/fermion/CayleyFermion5D.cc
@@ -73,7 +73,7 @@ void CayleyFermion5D<Impl>::DminusDag(const FermionField &psi, FermionField &chi
   this->DW(psi,tmp_f,DaggerYes);
 
   for(int s=0;s<Ls;s++){
-    axpby_ssp(chi,Coeff_t(1.0),psi,-cs[s],tmp_f,s,s);// chi = (1-c[s] D_W) psi
+    axpby_ssp(chi,Coeff_t(1.0),psi,conjugate(-cs[s]),tmp_f,s,s);// chi = (1-c[s] D_W)^\dagger psi (fixed) --dsh
   }
 }
 


### PR DESCRIPTION
We have the following current Grid code for D-^\Dagger

template<class Impl>
void CayleyFermion5D<Impl>::DminusDag(const FermionField &psi,
FermionField &chi)
{
  int Ls=this->Ls;

  FermionField tmp_f(this->FermionGrid());
  this->DW(psi,tmp_f,DaggerYes);

  for(int s=0;s<Ls;s++){
    axpby_ssp(chi,Coeff_t(1.0),psi,-cs[s],tmp_f,s,s);// chi = (1-c[s]
D_W) psi
  }
}

We see that
1) the comment should be changed for DminusDag and
2) -c[s] should be conjugate(-c[s])

For that stationary pion correlator on a 4^4 gauge config, nhits=0,
nl=10, ls=14 approx shamir ls=16 with eval range -1.45 to 1.45, we have

buggy version:

0 0 1.3942495791418983e+00 -1.3011571738330605e+00
0 1 1.2002588623680357e+00 -1.5026567844505334e+00
0 2 1.5390206837937441e+00 -1.6880218486968777e+00
0 3 1.6157177982204107e+00 -1.6171810596209881e+00
1 0 1.8284156242696930e+00 -1.7606379614592356e+00
1 1 1.9052990824275997e+00 -1.8981429672393153e+00
1 2 1.4221046968303250e+00 -1.6687164131414496e+00
1 3 1.2002588623680359e+00 -1.5026567844505334e+00
2 0 2.4812105152469845e+00 -2.2537459604657069e+00
2 1 2.0230585918888710e+00 -1.9478509074129520e+00
2 2 1.5390206837937441e+00 -1.6880218486968774e+00
2 3 1.9052990824276008e+00 -1.8981429672393149e+00
3 0 1.9730629207064390e+00 -1.9781174543663638e+00
3 1 1.6157177982204107e+00 -1.6171810596209883e+00
3 2 1.4221046968303250e+00 -1.6687164131414500e+00
3 3 2.0230585918888706e+00 -1.9478509074129517e+00

fixed:

0 0 2.3217390899813779e+00 1.3635833112043402e-01
0 1 2.2530454872578289e+00 -1.2384626997790542e-01
0 2 2.6853058186581942e+00 -3.8531658756815693e-03
0 3 2.7919963844721942e+00 6.4039709161604758e-02
1 0 3.0776915619348726e+00 5.6390510357766821e-02
1 1 3.2437259319996481e+00 8.9989415855548816e-02
1 2 2.6469812024920722e+00 1.0369836934643391e-02
1 3 2.2530454872578298e+00 -1.2384626997790536e-01
2 0 4.0119525033546521e+00 9.4092435732098315e-02
2 1 3.3705920280283164e+00 1.1913456274563280e-01
2 2 2.6853058186581937e+00 -3.8531658756816300e-03
2 3 3.2437259319996485e+00 8.9989415855548829e-02
3 0 3.4158851982362815e+00 -1.5592498869659533e-02
3 1 2.7919963844721947e+00 6.4039709161604758e-02
3 2 2.6469812024920718e+00 1.0369836934643391e-02
3 3 3.3705920280283159e+00 1.1913456274563282e-01

control, shamir:

0 0 4.4640652886541128e+00 -4.4382195796775763e-02
0 1 4.5454962762010771e+00 -1.8072141169287320e-02
0 2 4.8441155815331198e+00 2.8761354310137821e-03
0 3 4.9928790326788768e+00 -2.1750438508614418e-02
1 0 5.8504805676968017e+00 -1.1816949527092765e-03
1 1 6.0063331892571998e+00 -1.3290925105482642e-02
1 2 5.0596044085518619e+00 1.3469171513274342e-02
1 3 4.5454962762010789e+00 -1.8072141169287292e-02
2 0 6.5563516897122636e+00 5.0512080183835226e-02
2 1 5.4094108022453042e+00 3.4312728553910266e-02
2 2 4.8441155815331189e+00 2.8761354310137023e-03
2 3 6.0063331892572025e+00 -1.3290925105482597e-02
3 0 5.4962600986949770e+00 -6.6508919264119601e-02
3 1 4.9928790326788750e+00 -2.1750438508614391e-02
3 2 5.0596044085518610e+00 1.3469171513274376e-02
3 3 5.4094108022453034e+00 3.4312728553910279e-02

Have a good day.
