### PR TITLE
Add print of the current git hash on Grid init.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ make-bin-BUCK.sh
 #####################
 lib/qcd/spin/gamma-gen/*.h
 lib/qcd/spin/gamma-gen/*.cc
+lib/version.h
 
 # vs code editor files #
 ########################

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,6 +5,10 @@ include $(top_srcdir)/doxygen.inc
 
 bin_SCRIPTS=grid-config
 
+BUILT_SOURCES = version.h
+
+version.h:
+	echo "`git log -n 1 --format=format:"#define GITHASH \\"%H:%d\\"%n" HEAD`" > $(srcdir)/lib/version.h
 
 .PHONY: bench check tests doxygen-run doxygen-doc $(DX_PS_GOAL) $(DX_PDF_GOAL)
 

--- a/lib/util/Init.cc
+++ b/lib/util/Init.cc
@@ -49,6 +49,7 @@ Author: paboyle <paboyle@ph.ed.ac.uk>
 #include <Grid/Grid.h>
 
 #include <Grid/util/CompilerCompatible.h>
+#include <version.h>
 
 
 #include <fenv.h>
@@ -288,6 +289,12 @@ void Grid_init(int *argc,char ***argv)
     std::cout << "but WITHOUT ANY WARRANTY; without even the implied warranty of"<<std::endl;
     std::cout << "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"<<std::endl;
     std::cout << "GNU General Public License for more details."<<std::endl;
+#ifdef GITHASH
+    std::cout << "Current Grid git commit hash=" << GITHASH << std::endl;
+#else
+    std::cout << "Current Grid git commit hash is undefined. Check makefile." << std::endl;
+#endif
+#undef GITHASH
     std::cout << std::endl;
   }
 


### PR DESCRIPTION
Hi,

This commit creates a header file with the current git hash and prints this hash at the end of Grid's init messages.  The header file is created via a shell command executed in a new dependency for make's default target.  This dependency is introduced in Makefile.am using the standard BUILT_SOURCES variable.  This feature should be invisible to users, and provide information about the provenance of compiled binaries.