### PR TITLE
Add dimension check to precisionChange.

### DIFF
--- a/lib/lattice/Lattice_transfer.h
+++ b/lib/lattice/Lattice_transfer.h
@@ -652,6 +652,7 @@ vectorizeFromLexOrdArray( std::vector<sobj> &in, Lattice<vobj> &out)
 template<class VobjOut, class VobjIn>
 void precisionChange(Lattice<VobjOut> &out, const Lattice<VobjIn> &in){
   assert(out._grid->Nd() == in._grid->Nd());
+  assert(out._grid->FullDimensions() == in._grid->FullDimensions());
   out.checkerboard = in.checkerboard;
   GridBase *in_grid=in._grid;
   GridBase *out_grid = out._grid;


### PR DESCRIPTION
Hi,
I went down a fairly long rabbit hole trying to debug an MADWF routine before I realized that I was trying to do A2A subtraction between Mobius and Zmobius vectors.  I found the problem by using Valgrind, and the point of contact was attempting to convert a single precision Zmobius vector to a Mobius vector using precisionChange.  Now, this actually works sometimes (and on my laptop it never crashed), but this is something that clearly could've been prevented with an assert.  I've added that assert.  I wasn't sure whether it should be FullDimensions or GlobalDimensions, but I figured the former encompassed more.  Per:  
https://stackoverflow.com/questions/16422486/can-i-use-to-compare-two-vectors-i-tried-it-and-seems-to-be-working-fine 
it appears that == will compare both size and dimension contents in C++11, so this does two comparisons for us, and subsumes:
  assert(out._grid->Nd() == in._grid->Nd());
However, I left that in because it seems like a more helpful error message to get first.