### PR TITLE
Add printing of whether there are unstaged changes in the git hash print

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ bin_SCRIPTS=grid-config
 BUILT_SOURCES = version.h
 
 version.h:
-	echo "`git log -n 1 --format=format:"#define GITHASH \\"%H:%d\\"%n" HEAD`" > $(srcdir)/lib/version.h
+	if [ `git status --porcelain | wc -l` -gt 0 ]; then a="unstaged stanges"; else a="no unstaged changes"; fi; echo "`git log -n 1 --format=format:"#define GITHASH \\"%H:%d $$a\\"%n" HEAD`" > $(srcdir)/lib/version.h
 
 .PHONY: bench check tests doxygen-run doxygen-doc $(DX_PS_GOAL) $(DX_PDF_GOAL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ bin_SCRIPTS=grid-config
 BUILT_SOURCES = version.h
 
 version.h:
-	if [ `git status --porcelain | wc -l` -gt 0 ]; then a="unstaged stanges"; else a="no unstaged changes"; fi; echo "`git log -n 1 --format=format:"#define GITHASH \\"%H:%d $$a\\"%n" HEAD`" > $(srcdir)/lib/version.h
+	if [ `git status --porcelain | wc -l` -gt 0 ]; then a="uncommited changes"; else a="no uncommitted changes"; fi; echo "`git log -n 1 --format=format:"#define GITHASH \\"%H:%d $$a\\"%n" HEAD`" > $(srcdir)/lib/version.h
 
 .PHONY: bench check tests doxygen-run doxygen-doc $(DX_PS_GOAL) $(DX_PDF_GOAL)
 


### PR DESCRIPTION
This should tell someone unambiguously whether the working tree is clean when the binary is made.  Cursory tests seem to indicate this works.