### PR TITLE
fix patch command for eigen in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ wget ${EIGEN_URL} --no-check-certificate && ./scripts/update_eigen.sh ${ARC} && 
 # patch for non-portable includes in Eigen 3.3.5
 # apparently already fixed in Eigen HEAD so it should not be 
 # a problem in the future (A.P.)
-patch Grid/Eigen/unsupported/CXX11/Tensor scripts/eigen-3.3.5.Tensor.patch
+patch Eigen/unsupported/Eigen/CXX11/Tensor scripts/eigen-3.3.5.Tensor.patch
 
 echo '-- generating Make.inc files...'
 ./scripts/filelist


### PR DESCRIPTION
Fixes building with versions of GNU patch prior to 2.7.6.
Should solve issue #181 "not finding eigen .h files".