### PR TITLE
MFermion::GaugeProp fix for 4d fields

### DIFF
--- a/Hadrons/Modules/MFermion/GaugeProp.hpp
+++ b/Hadrons/Modules/MFermion/GaugeProp.hpp
@@ -111,12 +111,17 @@ void TGaugeProp<FImpl>::setup(void)
 {
     Ls_ = env().getObjectLs(par().solver);
     envCreateLat(PropagatorField, getName());
-    envTmpLat(FermionField, "source", Ls_);
-    envTmpLat(FermionField, "sol", Ls_);
     envTmpLat(FermionField, "tmp");
     if (Ls_ > 1)
     {
+        envTmpLat(FermionField, "source", Ls_);
+        envTmpLat(FermionField, "sol", Ls_);
         envCreateLat(PropagatorField, getName() + "_5d", Ls_);
+    }
+    else
+    {
+       envTmpLat(FermionField, "source");
+       envTmpLat(FermionField, "sol");
     }
 }
 


### PR DESCRIPTION
Fix for #194. Please check if there is a more general solution to the problem.

By general solution I mean something like always creating 4d fields if the 3rd argument to envTmpLat is 1 (do not naively do this!). Ideas are welcome.