### PR TITLE
Fix fussy compiler bugs (seen in gcc 7.4.0)

### DIFF
--- a/Grid/Makefile.am
+++ b/Grid/Makefile.am
@@ -21,7 +21,7 @@ if BUILD_HDF5
   extra_headers+=serialisation/Hdf5Type.h
 endif
 
-all: version-cache
+all: version-cache Version.h
 
 version-cache:
 	@if [ `git status --porcelain | grep -v '??' | wc -l` -gt 0 ]; then\

--- a/Hadrons/Global.hpp
+++ b/Hadrons/Global.hpp
@@ -118,7 +118,7 @@ typedef typename FImpl::DoubledGaugeField DoubledGaugeField##suffix;
 typedef typename GImpl::GaugeField GaugeField##suffix;
 
 #define SOLVER_TYPE_ALIASES(FImpl, suffix)\
-typedef Solver<FImpl> Solver##suffix;
+typedef class Solver<FImpl> Solver##suffix;
 
 #define SINK_TYPE_ALIASES(suffix)\
 typedef std::function<SlicedPropagator##suffix\


### PR DESCRIPTION
gives errors which look like:

In file included from /home/dan/test/Grid/Hadrons/Application.hpp:32:0,
                 from ../../Hadrons/Application.cc:29:
/home/dan/test/Grid/Hadrons/Global.hpp:121:23: error: declaration of ‘typedef class Grid::Hadrons::Solver<FImplOuter> Grid::Hadrons::MSolver::TMixedPrecisionRBPrecCG<FImplInner, FImplOuter, nBasis>::Solver’ [-fpermissive]
 typedef Solver<FImpl> Solver##suffix;
                       ^
/home/dan/test/Grid/Hadrons/Global.hpp:121:23: note: in definition of macro ‘SOLVER_TYPE_ALIASES’
 typedef Solver<FImpl> Solver##suffix;
                       ^~~~~~
In file included from /home/dan/test/Grid/Hadrons/Modules/MFermion/GaugeProp.hpp:38:0,
                 from /home/dan/test/Grid/Hadrons/Modules.hpp:11,
                 from ../../Hadrons/Application.cc:31:
/home/dan/test/Grid/Hadrons/Solver.hpp:36:7: error: changes meaning of ‘Solver’ from ‘class Grid::Hadrons::Solver<FImplOuter>’ [-fpermissive]
 class Solver
