### PR TITLE
Bugfix for A2ALoop module

### DIFF
--- a/Hadrons/Modules/MContraction/A2ALoop.hpp
+++ b/Hadrons/Modules/MContraction/A2ALoop.hpp
@@ -112,7 +112,7 @@ void TA2ALoop<FImpl>::execute(void)
     loop = zero;
     for (unsigned int i = 0; i < left.size(); ++i)
     {
-        loop += outerProduct(adj(left[i]), right[i]);
+        loop += outerProduct(left[i], right[i]);
     }
 }
 


### PR DESCRIPTION
Needed for running eye diagrams on 48^3.