### PR TITLE
Enable threading with nvcc

### DIFF
--- a/Grid/lattice/Lattice_transfer.h
+++ b/Grid/lattice/Lattice_transfer.h
@@ -112,7 +112,7 @@ inline void blockProject(Lattice<iVector<CComplex,nbasis > > &coarseData,
   auto fineData_   = fineData.View();
   auto coarseData_ = coarseData.View();
   // Loop over coars parallel, and then loop over fine associated with coarse.
-  thread_for( sf, fine->oSites(), {
+  nestable_thread_for( sf, fine->oSites() ) {
     int sc;
     Coordinate coor_c(_ndimension);
     Coordinate coor_f(_ndimension);
@@ -126,7 +126,7 @@ inline void blockProject(Lattice<iVector<CComplex,nbasis > > &coarseData,
 	coarseData_[sc](i)=coarseData_[sc](i) + innerProduct(Basis_[sf],fineData_[sf]);
       }
     }
-  });
+  }
   return;
 }
 
@@ -233,7 +233,7 @@ inline void blockSum(Lattice<vobj> &coarseData,const Lattice<vobj> &fineData)
   auto coarseData_ = coarseData.View();
   auto fineData_   = fineData.View();
 
-  thread_for(sf,fine->oSites(),{
+  nestable_thread_for(sf,fine->oSites()) {
     int sc;
     Coordinate coor_c(_ndimension);
     Coordinate coor_f(_ndimension);
@@ -246,7 +246,7 @@ inline void blockSum(Lattice<vobj> &coarseData,const Lattice<vobj> &fineData)
       coarseData_[sc]=coarseData_[sc]+fineData_[sf];
     }
 
-  });
+  }
   return;
 }
 

--- a/Grid/threads/Pragmas.h
+++ b/Grid/threads/Pragmas.h
@@ -8,6 +8,7 @@
 
 Author: Peter Boyle <paboyle@ph.ed.ac.uk>
 Author: paboyle <paboyle@ph.ed.ac.uk>
+Author: gfilaci <g.filaci@ed.ac.uk>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -57,9 +58,11 @@ Author: paboyle <paboyle@ph.ed.ac.uk>
 #define thread_max(a) (1)
 #endif
 
-#define naked_for(i,num,...) for ( uint64_t i=0;i<num;i++) { __VA_ARGS__ } ;
+#define naked_naked_for(i,num) for ( uint64_t i=0;i<num;i++)
+#define naked_for(i,num,...) naked_naked_for(i,num) { __VA_ARGS__ } ;
 #define naked_foreach(i,container,...) for ( uint64_t i=container.begin();i<container.end();i++) { __VA_ARGS__ } ;
 #define thread_for( i, num, ... )                           DO_PRAGMA(omp parallel for schedule(static)) naked_for(i,num,{__VA_ARGS__});
+#define nestable_thread_for(i,num)                          DO_PRAGMA(omp parallel for schedule(static)) naked_naked_for(i,num)
 #define thread_foreach( i, num, ... )                       DO_PRAGMA(omp parallel for schedule(static)) naked_foreach(i,num,{__VA_ARGS__});
 #define thread_for_in_region( i, num, ... )                 DO_PRAGMA(omp for schedule(static))          naked_for(i,num,{__VA_ARGS__});
 #define thread_for_collapse2( i, num, ... )                 DO_PRAGMA(omp parallel for collapse(2))      naked_for(i,num,{__VA_ARGS__});

--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,9 @@ case ${CXX} in
     CXX="nvcc -x cu "
     CXXLD="nvcc -link"
     CXXFLAGS="$CXXFLAGS -Xcompiler -fno-strict-aliasing -Xcompiler -Wno-unusable-partial-specialization --expt-extended-lambda --expt-relaxed-constexpr"
+    if test $ac_openmp = yes; then
+       CXXFLAGS="$CXXFLAGS -Xcompiler -fopenmp"
+    fi
     ;;
   *)
     CXXLD=${CXX}


### PR DESCRIPTION
I had to define a new "nestable_thread_for" so that it does not take the loop body as an argument. 
There is maybe a gcc preprocessor bug when _Pragma() are nested and passed in macro arguments: for example the loop
https://github.com/paboyle/Grid/blob/639dc1ab21552237ec3cc6b6538ca14f0f9c84df/Grid/lattice/Lattice_transfer.h#L236-L249
was preprocessed as 

`#pragma omp critical`
`#pragma omp parallel for schedule(static)`
  `for ( uint64_t sf=0;sf<fine->oSites();sf++) { {{ int sc; Coordinate coor_c(_ndimension); Coordinate coor_f(_ndimension); Lexicographic::CoorFromIndex(coor_f,sf,fine->_rdimensions); for(int d=0;d<_ndimension;d++) coor_c[d]=coor_f[d]/block_r[d];`
`Lexicographic::IndexFromCoor(coor_c,sc,coarse->_rdimensions); { coarseData_[sc]=coarseData_[sc]+fineData_[sf]; } }} } ;;`

The same code is interpreted correctly by the icpc preprocessor as

`_Pragma ("omp parallel for schedule(static)") for ( uint64_t sf=0;sf<fine ->oSites();sf++) { {{ int sc; Coordinate coor_c(_ndimension); Coordinate coor_f(_ndimension); Lexicographic::CoorFromIndex(coor_f,sf,fine ->_rdimensions); for(int d=0;d<_ndimension;d++) coor_c[d]=coor_f[d]/block_r[d]; Lexicographic::IndexFromCoor(coor_c,sc,coarse ->_rdimensions); _Pragma ("omp critical") { coarseData_[sc]=coarseData_[sc]+fineData_[sf]; } }} } ;;;`