### PR TITLE
MSource::jacobi smear + sort file contents of Modules.hpp and modules.inc

### DIFF
--- a/Hadrons/Modules.hpp
+++ b/Hadrons/Modules.hpp
@@ -1,8 +1,8 @@
 #include <Hadrons/Modules/MAction/DWF.hpp>
 #include <Hadrons/Modules/MAction/MobiusDWF.hpp>
 #include <Hadrons/Modules/MAction/ScaledDWF.hpp>
-#include <Hadrons/Modules/MAction/Wilson.hpp>
 #include <Hadrons/Modules/MAction/WilsonClover.hpp>
+#include <Hadrons/Modules/MAction/Wilson.hpp>
 #include <Hadrons/Modules/MAction/ZMobiusDWF.hpp>
 #include <Hadrons/Modules/MContraction/A2AAslashField.hpp>
 #include <Hadrons/Modules/MContraction/A2AFourQuarkContraction.hpp>
@@ -33,8 +33,8 @@
 #include <Hadrons/Modules/MGauge/Random.hpp>
 #include <Hadrons/Modules/MGauge/StochEm.hpp>
 #include <Hadrons/Modules/MGauge/StoutSmearing.hpp>
-#include <Hadrons/Modules/MGauge/Unit.hpp>
 #include <Hadrons/Modules/MGauge/UnitEm.hpp>
+#include <Hadrons/Modules/MGauge/Unit.hpp>
 #include <Hadrons/Modules/MIO/LoadA2AMatrixDiskVector.hpp>
 #include <Hadrons/Modules/MIO/LoadA2AVectors.hpp>
 #include <Hadrons/Modules/MIO/LoadBinary.hpp>
@@ -44,12 +44,12 @@
 #include <Hadrons/Modules/MIO/LoadEigenPack.hpp>
 #include <Hadrons/Modules/MIO/LoadNersc.hpp>
 #include <Hadrons/Modules/MIO/LoadPerambulator.hpp>
-#include <Hadrons/Modules/MNPR/Amputate.hpp>
-#include <Hadrons/Modules/MNPR/Bilinear.hpp>
-#include <Hadrons/Modules/MNPR/FourQuark.hpp>
 #include <Hadrons/Modules/MNoise/FullVolumeSpinColorDiagonal.hpp>
 #include <Hadrons/Modules/MNoise/SparseSpinColorDiagonal.hpp>
 #include <Hadrons/Modules/MNoise/TimeDilutedSpinColorDiagonal.hpp>
+#include <Hadrons/Modules/MNPR/Amputate.hpp>
+#include <Hadrons/Modules/MNPR/Bilinear.hpp>
+#include <Hadrons/Modules/MNPR/FourQuark.hpp>
 #include <Hadrons/Modules/MScalar/ChargedProp.hpp>
 #include <Hadrons/Modules/MScalar/FreeProp.hpp>
 #include <Hadrons/Modules/MScalar/Scalar.hpp>
@@ -57,10 +57,10 @@
 #include <Hadrons/Modules/MScalarSUN/EMT.hpp>
 #include <Hadrons/Modules/MScalarSUN/Grad.hpp>
 #include <Hadrons/Modules/MScalarSUN/StochFreeField.hpp>
+#include <Hadrons/Modules/MScalarSUN/TransProj.hpp>
 #include <Hadrons/Modules/MScalarSUN/TrKinetic.hpp>
 #include <Hadrons/Modules/MScalarSUN/TrMag.hpp>
 #include <Hadrons/Modules/MScalarSUN/TrPhi.hpp>
-#include <Hadrons/Modules/MScalarSUN/TransProj.hpp>
 #include <Hadrons/Modules/MScalarSUN/TwoPoint.hpp>
 #include <Hadrons/Modules/MScalarSUN/TwoPointNPR.hpp>
 #include <Hadrons/Modules/MScalarSUN/Utils.hpp>
@@ -74,6 +74,7 @@
 #include <Hadrons/Modules/MSolver/RBPrecCG.hpp>
 #include <Hadrons/Modules/MSource/Convolution.hpp>
 #include <Hadrons/Modules/MSource/Gauss.hpp>
+#include <Hadrons/Modules/MSource/JacobiSmear.hpp>
 #include <Hadrons/Modules/MSource/Momentum.hpp>
 #include <Hadrons/Modules/MSource/MomentumPhase.hpp>
 #include <Hadrons/Modules/MSource/Point.hpp>

--- a/Hadrons/Modules/MSource/JacobiSmear.cc
+++ b/Hadrons/Modules/MSource/JacobiSmear.cc
@@ -1,0 +1,7 @@
+#include <Hadrons/Modules/MSource/JacobiSmear.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MSource;
+
+template class Grid::Hadrons::MSource::TJacobiSmear<FIMPL>;

--- a/Hadrons/Modules/MSource/JacobiSmear.hpp
+++ b/Hadrons/Modules/MSource/JacobiSmear.hpp
@@ -1,0 +1,105 @@
+#ifndef Hadrons_MSource_JacobiSmear_hpp_
+#define Hadrons_MSource_JacobiSmear_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                         JacobiSmear                                 *
+ ******************************************************************************/
+BEGIN_MODULE_NAMESPACE(MSource)
+
+class JacobiSmearPar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(JacobiSmearPar,
+                                    std::string, gauge,
+                                    double, width,
+                                    int, iterations,
+                                    int, orthog,
+                                    std::string, source);
+};
+
+template <typename FImpl>
+class TJacobiSmear: public Module<JacobiSmearPar>
+{
+public:
+    FERM_TYPE_ALIASES(FImpl,);
+    typedef typename FImpl::GaugeLinkField GaugeMat;
+public:
+    // constructor
+    TJacobiSmear(const std::string name);
+    // destructor
+    virtual ~TJacobiSmear(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+};
+
+MODULE_REGISTER_TMP(JacobiSmear, TJacobiSmear<FIMPL>, MSource);
+
+/******************************************************************************
+ *                 TJacobiSmear implementation                             *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename FImpl>
+TJacobiSmear<FImpl>::TJacobiSmear(const std::string name)
+: Module<JacobiSmearPar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename FImpl>
+std::vector<std::string> TJacobiSmear<FImpl>::getInput(void)
+{
+    std::vector<std::string> in = {par().source, par().gauge};
+    
+    return in;
+}
+
+template <typename FImpl>
+std::vector<std::string> TJacobiSmear<FImpl>::getOutput(void)
+{
+    std::vector<std::string> out = {getName()};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TJacobiSmear<FImpl>::setup(void)
+{
+    envCreateLat(PropagatorField, getName());
+    envTmp(std::vector<GaugeMat>, "Umu", 1, 4, envGetGrid(LatticeColourMatrix));
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TJacobiSmear<FImpl>::execute(void)
+{
+    auto &out = envGet(PropagatorField, getName());
+    auto &src = envGet(PropagatorField, par().source);
+    auto &U = envGet(GaugeField, par().gauge);
+    envGetTmp(std::vector<GaugeMat>, Umu);
+    for(int mu=0; mu<4; mu++)
+    {
+       Umu.at(mu)=peekLorentz(U,mu);
+    }
+    CovariantSmearing<FImpl> covsmear;
+    out=src;
+    startTimer("Jacobi iteration");
+    covsmear.GaussianSmear(Umu, out, par().width, par().iterations, par().orthog);
+    stopTimer("Jacobi iteration");
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MSource_JacobiSmear_hpp_

--- a/Hadrons/modules.inc
+++ b/Hadrons/modules.inc
@@ -44,22 +44,22 @@ modules_cc =\
   Modules/MIO/LoadEigenPack.cc \
   Modules/MIO/LoadNersc.cc \
   Modules/MIO/LoadPerambulator.cc \
-  Modules/MNPR/Amputate.cc \
-  Modules/MNPR/Bilinear.cc \
-  Modules/MNPR/FourQuark.cc \
   Modules/MNoise/FullVolumeSpinColorDiagonal.cc \
   Modules/MNoise/SparseSpinColorDiagonal.cc \
   Modules/MNoise/TimeDilutedSpinColorDiagonal.cc \
+  Modules/MNPR/Amputate.cc \
+  Modules/MNPR/Bilinear.cc \
+  Modules/MNPR/FourQuark.cc \
   Modules/MScalar/ChargedProp.cc \
   Modules/MScalar/FreeProp.cc \
   Modules/MScalarSUN/Div.cc \
   Modules/MScalarSUN/EMT.cc \
   Modules/MScalarSUN/Grad.cc \
   Modules/MScalarSUN/StochFreeField.cc \
+  Modules/MScalarSUN/TransProj.cc \
   Modules/MScalarSUN/TrKinetic.cc \
   Modules/MScalarSUN/TrMag.cc \
   Modules/MScalarSUN/TrPhi.cc \
-  Modules/MScalarSUN/TransProj.cc \
   Modules/MScalarSUN/TwoPoint.cc \
   Modules/MScalarSUN/TwoPointNPR.cc \
   Modules/MSink/Point.cc \
@@ -71,6 +71,7 @@ modules_cc =\
   Modules/MSolver/RBPrecCG.cc \
   Modules/MSource/Convolution.cc \
   Modules/MSource/Gauss.cc \
+  Modules/MSource/JacobiSmear.cc \
   Modules/MSource/Momentum.cc \
   Modules/MSource/MomentumPhase.cc \
   Modules/MSource/Point.cc \
@@ -86,8 +87,8 @@ modules_hpp =\
   Modules/MAction/DWF.hpp \
   Modules/MAction/MobiusDWF.hpp \
   Modules/MAction/ScaledDWF.hpp \
-  Modules/MAction/Wilson.hpp \
   Modules/MAction/WilsonClover.hpp \
+  Modules/MAction/Wilson.hpp \
   Modules/MAction/ZMobiusDWF.hpp \
   Modules/MContraction/A2AAslashField.hpp \
   Modules/MContraction/A2AFourQuarkContraction.hpp \
@@ -118,8 +119,8 @@ modules_hpp =\
   Modules/MGauge/Random.hpp \
   Modules/MGauge/StochEm.hpp \
   Modules/MGauge/StoutSmearing.hpp \
-  Modules/MGauge/Unit.hpp \
   Modules/MGauge/UnitEm.hpp \
+  Modules/MGauge/Unit.hpp \
   Modules/MIO/LoadA2AMatrixDiskVector.hpp \
   Modules/MIO/LoadA2AVectors.hpp \
   Modules/MIO/LoadBinary.hpp \
@@ -129,12 +130,12 @@ modules_hpp =\
   Modules/MIO/LoadEigenPack.hpp \
   Modules/MIO/LoadNersc.hpp \
   Modules/MIO/LoadPerambulator.hpp \
-  Modules/MNPR/Amputate.hpp \
-  Modules/MNPR/Bilinear.hpp \
-  Modules/MNPR/FourQuark.hpp \
   Modules/MNoise/FullVolumeSpinColorDiagonal.hpp \
   Modules/MNoise/SparseSpinColorDiagonal.hpp \
   Modules/MNoise/TimeDilutedSpinColorDiagonal.hpp \
+  Modules/MNPR/Amputate.hpp \
+  Modules/MNPR/Bilinear.hpp \
+  Modules/MNPR/FourQuark.hpp \
   Modules/MScalar/ChargedProp.hpp \
   Modules/MScalar/FreeProp.hpp \
   Modules/MScalar/Scalar.hpp \
@@ -142,10 +143,10 @@ modules_hpp =\
   Modules/MScalarSUN/EMT.hpp \
   Modules/MScalarSUN/Grad.hpp \
   Modules/MScalarSUN/StochFreeField.hpp \
+  Modules/MScalarSUN/TransProj.hpp \
   Modules/MScalarSUN/TrKinetic.hpp \
   Modules/MScalarSUN/TrMag.hpp \
   Modules/MScalarSUN/TrPhi.hpp \
-  Modules/MScalarSUN/TransProj.hpp \
   Modules/MScalarSUN/TwoPoint.hpp \
   Modules/MScalarSUN/TwoPointNPR.hpp \
   Modules/MScalarSUN/Utils.hpp \
@@ -159,6 +160,7 @@ modules_hpp =\
   Modules/MSolver/RBPrecCG.hpp \
   Modules/MSource/Convolution.hpp \
   Modules/MSource/Gauss.hpp \
+  Modules/MSource/JacobiSmear.hpp \
   Modules/MSource/Momentum.hpp \
   Modules/MSource/MomentumPhase.hpp \
   Modules/MSource/Point.hpp \


### PR DESCRIPTION
1) Add module MSource::JacobiSmear.

2) The script make_module_list.sh recreates the files Modules.hpp and modules.inc. The output is not sorted which leads to large diffs. This unnecessarily increases the git history due to the large diffs and makes it harder to see what has actually changed. Therefore I suggest to use the sort command in make_module_list.sh as implemented in this merge request.

Please feel free to comment on both parts of the merge request. If wished for, I can remove the second part.