### PR TITLE
A few run /compile / memory leak fixes

### DIFF
--- a/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
+++ b/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
@@ -62,9 +62,12 @@ void basisRotate(std::vector<Field> &basis,Eigen::MatrixXd& Qt,int j0, int j1, i
     basis_v[k] = basis[k].View();
   }
 
+  std::vector < vobj , commAllocator<vobj> > Bt(thread_max() * Nm); // Thread private
+
   thread_region
   {
-    std::vector < vobj , commAllocator<vobj> > B(Nm); // Thread private
+    vobj* B = Bt.data() + Nm * thread_num();
+
     thread_for_in_region(ss, grid->oSites(),{
       for(int j=j0; j<j1; ++j) B[j]=0.;
       

--- a/Grid/lattice/Lattice_base.h
+++ b/Grid/lattice/Lattice_base.h
@@ -178,8 +178,8 @@ public:
 private:
   void dealloc(void)
   {
-    alignedAllocator<vobj> alloc;
     if( this->_odata_size ) {
+      alignedAllocator<vobj> alloc;
       alloc.deallocate(this->_odata,this->_odata_size);
       this->_odata=nullptr;
       this->_odata_size=0;
@@ -187,15 +187,17 @@ private:
   }
   void resize(uint64_t size)
   {
-    alignedAllocator<vobj> alloc;
     if ( this->_odata_size != size ) {
+      alignedAllocator<vobj> alloc;
+
       dealloc();
+      
+      this->_odata_size = size;
+      if ( size ) 
+	this->_odata      = alloc.allocate(this->_odata_size);
+      else 
+	this->_odata      = nullptr;
     }
-    this->_odata_size = size;
-    if ( size ) 
-      this->_odata      = alloc.allocate(this->_odata_size);
-    else 
-      this->_odata      = nullptr;
   }
 public:
   /////////////////////////////////////////////////////////////////////////////////
@@ -346,7 +348,7 @@ public:
   void reset(GridBase* grid) {
     if (this->_grid != grid) {
       this->_grid = grid;
-      this->_odata.resize(grid->oSites());
+      this->resize(grid->oSites());
       this->checkerboard = 0;
     }
   }


### PR DESCRIPTION
I found that the Lanczos would not run because the basis rotate was allocating aligned memory within a parallel region, which was causing the pointer-cache check for execution outside threaded region to fail. I have fixed this by performing the allocation outside the threaded region.

I have also fixed a no-compile on Lattice::reset, which was calling _odata->resize, which no longer works because _odata is not an std::vector. I also fixed a memory leak in Lattice::resize where a new memory allocation would be performed even if the existing size was equal to the desired size, alongside it not deallocating the existing memory region for this case. I fixed by moving all the code inside the check that the desired size is different from the existing size.

With these fixes I am able to reproduce my existing 4^4 K->pipi results.