### PR TITLE
several typos in hadrons

### DIFF
--- a/Hadrons/Global.hpp
+++ b/Hadrons/Global.hpp
@@ -272,7 +272,7 @@ struct Correlator: Serializable
 {
     GRID_SERIALIZABLE_CLASS_MEMBERS(ARG(Correlator<Metadata, Scalar>),
                                     Metadata,             info,
-                                    std::vector<Complex>, corr);
+                                    std::vector<Scalar>, corr);
 };
 
 END_HADRONS_NAMESPACE

--- a/Hadrons/Modules/MContraction/WeakEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakEye3pt.hpp
@@ -144,7 +144,7 @@ void TWeakEye3pt<FImpl>::execute(void)
 {
     LOG(Message) << "Computing mesonic weak 3pt contractions, eye topologies" << std::endl;
     LOG(Message) << "gIn : " << par().gammaIn << std::endl;
-    LOG(Message) << "gOut: " << par().gammaIn << std::endl;
+    LOG(Message) << "gOut: " << par().gammaOut << std::endl;
     LOG(Message) << "tOut: " << par().tOut << std::endl;
     LOG(Message) << "qbl : " << par().qBarLeft << std::endl;
     LOG(Message) << "qbr : " << par().qBarRight << std::endl;

--- a/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
+++ b/Hadrons/Modules/MContraction/WeakNonEye3pt.hpp
@@ -144,7 +144,7 @@ void TWeakNonEye3pt<FImpl>::execute(void)
 {
     LOG(Message) << "Computing mesonic weak 3pt contractions, non-eye topologies" << std::endl;
     LOG(Message) << "gIn : " << par().gammaIn << std::endl;
-    LOG(Message) << "gOut: " << par().gammaIn << std::endl;
+    LOG(Message) << "gOut: " << par().gammaOut << std::endl;
     LOG(Message) << "ql  : " << par().qLeft << std::endl;
     LOG(Message) << "qbl : " << par().qBarLeft << std::endl;
     LOG(Message) << "qr  : " << par().qRight << std::endl;


### PR DESCRIPTION
Three typos:
1) Most important: Global.hpp did not use the template 'Scalar' in struct Correlator. No Module used any other type than Complex so far, so all existing code was not broken.

2)WeakEye / NonEye modules printed gammaIn twice, and not gammaOut. Not crucial at all, old log files just show the wrong gamma matrices.