### PR TITLE
Updated Eigen URL after migration to gitlab

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-EIGEN_URL='http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2'
+EIGEN_URL='https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2'
 
 echo "-- deploying Eigen source..."
 ARC=`basename ${EIGEN_URL}`


### PR DESCRIPTION
This was announced last week:
http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th

The process has started today so bitbucket URL in bootstrap.sh is now outdated and give a "401 Unauthorized" response. The new URL is:
https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2

which is not publicly available yet but they say it should be "soon."

Patch can be done manually using the git-mirror repo:
https://github.com/eigenteam/eigen-git-mirror/archive/3.3.7.tar.gz
and some manual changes to scripts/update_eigen.sh until the new URL is publicly available.