### PR TITLE
Added NamedTensor.hpp

### DIFF
--- a/Hadrons/Makefile.am
+++ b/Hadrons/Makefile.am
@@ -31,6 +31,7 @@ nobase_libHadrons_a_HEADERS = \
 	Module.hpp                \
 	Modules.hpp               \
 	ModuleFactory.hpp         \
+        NamedTensor.hpp           \
 	Solver.hpp                \
 	TimerArray.hpp            \
 	VirtualMachine.hpp        \


### PR DESCRIPTION
Added NamedTensor.hpp to Makefile.am in Hadrons. Seems like NamedTensor.hpp is required by Modules like MDistil.