### PR TITLE
fix computing nt from GlobalDimensions

### DIFF
--- a/Hadrons/DilutedNoise.hpp
+++ b/Hadrons/DilutedNoise.hpp
@@ -190,7 +190,8 @@ TimeDilutedSpinColorDiagonalNoise<FImpl>::
 TimeDilutedSpinColorDiagonalNoise(GridCartesian *g)
 : DilutedNoise<FImpl>(g)
 {
-    nt_ = this->getGrid()->GlobalDimensions().size();
+    const auto &dimen = this->getGrid()->GlobalDimensions();
+    nt_ = dimen[dimen.size()-1];
     this->resize(nt_*Ns*FImpl::Dimension);
 }
 

--- a/tests/core/Test_qed.cc
+++ b/tests/core/Test_qed.cc
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 
       std::cout << GridLogMessage << "Spatial zero-mode norm 2" << std::endl;
       sliceSum(a, zm, grid.Nd() - 1);
-      for (unsigned int t = 0; t < latt_size.size(); ++t)
+      for (unsigned int t = 0; t < lat_size[latt_size.size()-1]; ++t)
       {
         std::cout << GridLogMessage << "t = " << t << " " << std::sqrt(norm2(zm[t])) << std::endl;
       }


### PR DESCRIPTION
Fixes a regression in Hadrons/DilutedNoise.hpp and Test_qed.cc that leads to an incorrect value for the number of time slices.