### PR TITLE
Xi sigma

### DIFF
--- a/Grid/qcd/utils/BaryonUtils.h
+++ b/Grid/qcd/utils/BaryonUtils.h
@@ -681,7 +681,7 @@ void BaryonUtils<FImpl>::Xi_to_Sigma_Q1_Eye_site(const mobj &Dq_loop,
   //  Ds * \gamma_\mu^L * Dd
   auto DsGDd = Ds_ti * Gamma_H * Dd_tf;
   // Ds * \gamma_\mu^L * Dd * \Gamma^B
-  auto GDsGDd = GammaB_sigma * DsGDd;
+  auto GDsGDd = GammaB_xi * DsGDd;
   // Ds * \gamma_\mu^L * Dd * \Gamma^B
   auto DsGDdG = DsGDd * GammaB_sigma;
   // Gamma^B * Ds * \gamma_\mu^L * Dd * \Gamma^B
@@ -762,7 +762,7 @@ void BaryonUtils<FImpl>::Xi_to_Sigma_Q2_Eye_site(const mobj &Dq_loop,
         auto Ds_ab_ab = Ds_spec()(alpha_x, beta_s)(a_x,b_s);
         auto GDs_ab_bb = GDs()(alpha_x, beta_s)(b_x,b_s);
         auto DsGDqGDdG_ab_aa = DsGDqGDdG()(alpha_x, beta_s)(a_x,a_s);
-        auto GDsGDqGDdG_ab_ba = GDsGDqGDdG()(alpha_x, beta_s)(a_x,b_s);
+        auto GDsGDqGDdG_ab_ba = GDsGDqGDdG()(alpha_x, beta_s)(b_x,a_s);
         for (int gamma_x=0; gamma_x<Ns; gamma_x++){
         for (int gamma_s=0; gamma_s<Ns; gamma_s++){
           result()(gamma_x,gamma_s)() -= ee * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * GDsGDqGDdG_ab_ba * Ds_ab_ab;

--- a/Grid/qcd/utils/BaryonUtils.h
+++ b/Grid/qcd/utils/BaryonUtils.h
@@ -690,23 +690,22 @@ void BaryonUtils<FImpl>::Xi_to_Sigma_Q1_Eye_site(const mobj &Dq_loop,
   auto GDq = Gamma_H * Dq_loop;
 
   for (int ie_s=0; ie_s < 6 ; ie_s++){
-    int a_s = epsilon[ie_n][0]; //a
-    int b_s = epsilon[ie_n][1]; //b
-    int c_s = epsilon[ie_n][2]; //c
+    int a_s = epsilon[ie_s][0]; //a
+    int b_s = epsilon[ie_s][1]; //b
+    int c_s = epsilon[ie_s][2]; //c
     for (int ie_x=0; ie_x < 6 ; ie_x++){
-      int a_x = epsilon[ie_s][0]; //a'
-      int b_x = epsilon[ie_s][1]; //b'
-      int c_x = epsilon[ie_s][2]; //c'
+      int a_x = epsilon[ie_x][0]; //a'
+      int b_x = epsilon[ie_x][1]; //b'
+      int c_x = epsilon[ie_x][2]; //c'
       for (int sigma2=0; sigma2<Ns; sigma2++){
       for (int j=0; j<Nc; j++){
         auto GDq_jj_ss=GDq()(sigma2,sigma2)(j,j);
         auto ee_GD = epsilon_sgn[ie_s] * epsilon_sgn[ie_x] * GDq_jj_ss;
         for (int alpha_x=0; alpha_x<Ns; alpha_x++){
         for (int beta_s=0; beta_s<Ns; beta_s++){
-          auto GDsGDd_ab_bb = GDsGDd()(alpha_s,beta_n)(b_s,b_n);
-          auto DqG_tt_jj = DqG()(tau2,tau2)(j,j);
-        for (int gamma_s=0; gamma_s<Ns; gamma_s++){
-        for (int gamma_n=0; gamma_n<Ns; gamma_n++){
+          auto GDsGDd_ab_bb = GDsGDd()(alpha_x,beta_s)(b_x,b_s);
+          for (int gamma_x=0; gamma_x<Ns; gamma_x++){
+          for (int gamma_s=0; gamma_s<Ns; gamma_s++){
             result()(gamma_x,gamma_s)() -= ee_GD * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * GDsGDdG()(alpha_x, beta_s)(b_x,a_s) * Ds_spec()(alpha_x, beta_s)(a_x, b_s);
             result()(gamma_x,gamma_s)() += ee_GD * DdG()(gamma_x, beta_s)(c_x,a_s) * GDsGDd()(alpha_x, gamma_s)(b_x,c_s) * Ds_spec()(alpha_x, beta_s)(a_x, b_s);
             result()(gamma_x,gamma_s)() += ee_GD * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * DsGDdG()(alpha_x, beta_s)(a_x,a_s) * GDs()(alpha_x, beta_s)(b_x, b_s);
@@ -741,7 +740,7 @@ void BaryonUtils<FImpl>::Xi_to_Sigma_Q2_Eye_site(const mobj &Dq_loop,
   auto DdG = Dd_spec * GammaB_sigma;
   auto GDs = GammaB_xi * Ds_spec;
   //  Ds * gamma_mu^L * Dq * \gamma_\mu^L * Dd
-  auto DsGDqGDd = Ds_xi * Gamma_H * Dq_loop * Gamma_H * Dd_tf;
+  auto DsGDqGDd = Ds_ti * Gamma_H * Dq_loop * Gamma_H * Dd_tf;
   //  Ds * gamma_mu^L * Dq * \gamma_\mu^L * Dd * GammaB
   auto DsGDqGDdG = DsGDqGDd * GammaB_sigma;
   //  GammaB * Ds * gamma_mu^L * Dq * \gamma_\mu^L * Dd
@@ -750,28 +749,27 @@ void BaryonUtils<FImpl>::Xi_to_Sigma_Q2_Eye_site(const mobj &Dq_loop,
   auto GDsGDqGDdG = GammaB_xi * DsGDqGDdG; 
 
   for (int ie_s=0; ie_s < 6 ; ie_s++){
-    int a_s = epsilon[ie_n][0]; //a
-    int b_s = epsilon[ie_n][1]; //b
-    int c_s = epsilon[ie_n][2]; //c
+    int a_s = epsilon[ie_s][0]; //a
+    int b_s = epsilon[ie_s][1]; //b
+    int c_s = epsilon[ie_s][2]; //c
     for (int ie_x=0; ie_x < 6 ; ie_x++){
-      int a_x = epsilon[ie_s][0]; //a'
-      int b_x = epsilon[ie_s][1]; //b'
-      int c_x = epsilon[ie_s][2]; //c'
-        auto ee = epsilon_sgn[ie_s] * epsilon_sgn[ie_x];
-        for (int alpha_x=0; alpha_x<Ns; alpha_x++){
-        for (int beta_s=0; beta_s<Ns; beta_s++){
-          auto Ds_ab_ab = Ds_spec()(alpha_x, beta_s)(a_x,b_s);
-          auto GDs_ab_bb = GDs()(alpha_x, beta_s)(b_x,b_s);
-          auto DsGDqGDdG_ab_aa = DsGDqGDdG()(alpha_x, beta_s)(a_x,a_s);
-          auto GDsGDqGDdG_ab_ba = GDsGDqGDdG()(alpha_x, beta_s)(a_x,b_s);
-      	  for (int gamma_s=0; gamma_s<Ns; gamma_s++){
-          for (int gamma_n=0; gamma_n<Ns; gamma_n++){
-            result()(gamma_x,gamma_s)() -= ee * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * GDsGDqGDdG_ab_ba * Ds_ab_ab;
-            result()(gamma_x,gamma_s)() += ee * DdG()(gamma_x, beta_s)(c_x,a_s) * GDsGDqGDd()(alpha_x,gamma_s)(b_x,c_s) * Ds_ab_ab;
-            result()(gamma_x,gamma_s)() += ee * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * DsGDqGDdG_ab_aa * GDs_ab_bb;
-            result()(gamma_x,gamma_s)() -= ee * DdG()(gamma_x, beta_s)(c_x,a_s) * DsGDqGDd()(alpha_x,gamma_s)(a_x,c_s) * GDs_ab_bb;
-          }}
-	}}
+      int a_x = epsilon[ie_x][0]; //a'
+      int b_x = epsilon[ie_x][1]; //b'
+      int c_x = epsilon[ie_x][2]; //c'
+      auto ee = epsilon_sgn[ie_s] * epsilon_sgn[ie_x];
+      for (int alpha_x=0; alpha_x<Ns; alpha_x++){
+      for (int beta_s=0; beta_s<Ns; beta_s++){
+        auto Ds_ab_ab = Ds_spec()(alpha_x, beta_s)(a_x,b_s);
+        auto GDs_ab_bb = GDs()(alpha_x, beta_s)(b_x,b_s);
+        auto DsGDqGDdG_ab_aa = DsGDqGDdG()(alpha_x, beta_s)(a_x,a_s);
+        auto GDsGDqGDdG_ab_ba = GDsGDqGDdG()(alpha_x, beta_s)(a_x,b_s);
+        for (int gamma_x=0; gamma_x<Ns; gamma_x++){
+        for (int gamma_s=0; gamma_s<Ns; gamma_s++){
+          result()(gamma_x,gamma_s)() -= ee * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * GDsGDqGDdG_ab_ba * Ds_ab_ab;
+          result()(gamma_x,gamma_s)() += ee * DdG()(gamma_x, beta_s)(c_x,a_s) * GDsGDqGDd()(alpha_x,gamma_s)(b_x,c_s) * Ds_ab_ab;
+          result()(gamma_x,gamma_s)() += ee * Dd_spec()(gamma_x, gamma_s)(c_x,c_s) * DsGDqGDdG_ab_aa * GDs_ab_bb;
+          result()(gamma_x,gamma_s)() -= ee * DdG()(gamma_x, beta_s)(c_x,a_s) * DsGDqGDd()(alpha_x,gamma_s)(a_x,c_s) * GDs_ab_bb;
+        }}
       }}
     }
   }

--- a/Hadrons/Modules.hpp
+++ b/Hadrons/Modules.hpp
@@ -17,6 +17,7 @@
 #include <Hadrons/Modules/MContraction/WeakEye3pt.hpp>
 #include <Hadrons/Modules/MContraction/WeakMesonDecayKl2.hpp>
 #include <Hadrons/Modules/MContraction/WeakNonEye3pt.hpp>
+#include <Hadrons/Modules/MContraction/XiToSigmaEye.hpp>
 #include <Hadrons/Modules/MDistil/Distil.hpp>
 #include <Hadrons/Modules/MDistil/DistilPar.hpp>
 #include <Hadrons/Modules/MDistil/DistilVectors.hpp>

--- a/Hadrons/Modules/MContraction/XiToSigmaEye.cc
+++ b/Hadrons/Modules/MContraction/XiToSigmaEye.cc
@@ -1,0 +1,7 @@
+#include <Hadrons/Modules/MContraction/XiToSigmaEye.hpp>
+
+using namespace Grid;
+using namespace Hadrons;
+using namespace MContraction;
+
+template class Grid::Hadrons::MContraction::TXiToSigmaEye<FIMPL>;

--- a/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
+++ b/Hadrons/Modules/MContraction/XiToSigmaEye.hpp
@@ -1,0 +1,222 @@
+/*************************************************************************************
+
+Grid physics library, www.github.com/paboyle/Grid 
+
+Source file: Hadrons/Modules/MContraction/XiToSigmaEye.hpp
+
+Copyright (C) 2015-2019
+
+Author: Antonin Portelli <antonin.portelli@me.com>
+Author: Felix Erben <felix.erben@ed.ac.uk>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+
+#ifndef Hadrons_MContraction_XiToSigmaEye_hpp_
+#define Hadrons_MContraction_XiToSigmaEye_hpp_
+
+#include <Hadrons/Global.hpp>
+#include <Hadrons/Module.hpp>
+#include <Hadrons/ModuleFactory.hpp>
+#include <Grid/qcd/utils/BaryonUtils.h>
+
+BEGIN_HADRONS_NAMESPACE
+
+/******************************************************************************
+ *                               XiToSigmaEye                                       *
+ ******************************************************************************/
+/*
+ * Xi-to-Sigma 3-pt diagrams, (only eye topologies occur).
+ * 
+ * Schematics:      qqLoop                |                  
+ *                  /->-¬                 |                             
+ *                 /     \                |          qsTi      G     qdTf
+ *                 \     /                |        /---->------*------>----¬         
+ *          qsTi    \   /    qdTf         |       /          /-*-¬          \
+ *       /----->-----* *----->----¬       |      /          /  G  \          \
+ *      *            G G           *      |     *           \     /  qqLoop  * 
+ *      |\                        /|      |     |\           \-<-/          /|   
+ *      | \                      / |      |     | \                        / |      
+ *      |  \---------->---------/  |      |     |  \----------->----------/  |      
+ *       \          qdSpec        /       |      \          qdSpec          /        
+ *        \                      /        |       \                        /
+ *         \---------->---------/         |        \----------->----------/
+ *                  qsSpec                |                 qsSpec
+ * 
+ * analogously to the rare-kaon naming, the left diagram is named 'one-trace' and
+ * the diagram on the right 'two-trace'
+ *
+ * Propagators:
+ *  * qqLoop
+ *  * qdSpec, source at ti
+ *  * qdTf,   source at tf 
+ *  * qsSpec, source at ti
+ *  * qsTi,   source at ti
+ */
+BEGIN_MODULE_NAMESPACE(MContraction)
+
+class XiToSigmaEyePar: Serializable
+{
+public:
+    GRID_SERIALIZABLE_CLASS_MEMBERS(XiToSigmaEyePar,
+                                    std::string, qqLoop,
+                                    std::string, qdSpec,
+                                    std::string, qdTf,
+                                    std::string, qsSpec,
+                                    std::string, qsTi,
+                                    unsigned int,   tf,
+                                    std::string, sink,
+                                    std::string, output);
+};
+
+template <typename FImpl>
+class TXiToSigmaEye: public Module<XiToSigmaEyePar>
+{
+public:
+    FERM_TYPE_ALIASES(FImpl,);
+    BASIC_TYPE_ALIASES(ScalarImplCR, Scalar);
+    SINK_TYPE_ALIASES(Scalar);
+    typedef typename SpinMatrixField::vector_object::scalar_object SpinMatrix;
+    class Metadata: Serializable
+    {
+    public:
+        GRID_SERIALIZABLE_CLASS_MEMBERS(Metadata,
+                                        Gamma::Algebra, gammaH,
+                                        Gamma::Algebra, gammaAXi,
+                                        Gamma::Algebra, gammaBXi,
+                                        Gamma::Algebra, gammaASigma,
+                                        Gamma::Algebra, gammaBSigma,
+                                        int, trace);
+    };
+    typedef Correlator<Metadata, SpinMatrix> Result;
+public:
+    // constructor
+    TXiToSigmaEye(const std::string name);
+    // destructor
+    virtual ~TXiToSigmaEye(void) {};
+    // dependency relation
+    virtual std::vector<std::string> getInput(void);
+    virtual std::vector<std::string> getOutput(void);
+protected:
+    // setup
+    virtual void setup(void);
+    // execution
+    virtual void execute(void);
+    // Which gamma algebra was specified
+    Gamma::Algebra  al;
+};
+
+MODULE_REGISTER_TMP(XiToSigmaEye, ARG(TXiToSigmaEye<FIMPL>), MContraction);
+
+/******************************************************************************
+ *                         TXiToSigmaEye implementation                             *
+ ******************************************************************************/
+// constructor /////////////////////////////////////////////////////////////////
+template <typename FImpl>
+TXiToSigmaEye<FImpl>::TXiToSigmaEye(const std::string name)
+: Module<XiToSigmaEyePar>(name)
+{}
+
+// dependencies/products ///////////////////////////////////////////////////////
+template <typename FImpl>
+std::vector<std::string> TXiToSigmaEye<FImpl>::getInput(void)
+{
+    std::vector<std::string> input = {par().qqLoop, par().qdSpec, par().qdTf, par().qsSpec, par().qsTi, par().sink};
+    
+    return input;
+}
+
+template <typename FImpl>
+std::vector<std::string> TXiToSigmaEye<FImpl>::getOutput(void)
+{
+    std::vector<std::string> out = {};
+    
+    return out;
+}
+
+// setup ///////////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TXiToSigmaEye<FImpl>::setup(void)
+{
+    envTmpLat(SpinMatrixField, "c");
+}
+
+// execution ///////////////////////////////////////////////////////////////////
+template <typename FImpl>
+void TXiToSigmaEye<FImpl>::execute(void)
+{
+    const Gamma GammaB(Gamma::Algebra::SigmaXZ); // C*gamma_5
+    const Gamma Id(Gamma::Algebra::Identity); // C*gamma_5
+
+    LOG(Message) << "Computing xi-to-sigma contractions '" << getName() << "'" << std::endl;
+    LOG(Message) << "' with (Gamma^A,Gamma^B)_xi = ( Identity, C*gamma_5 ) and (Gamma^A,Gamma^B)_sigma = ( Identity, C*gamma_5 )" << std::endl; 
+    LOG(Message) << " using sink " << par().sink << "." << std::endl;
+        
+    envGetTmp(SpinMatrixField, c);
+    std::vector<SpinMatrix> buf;
+
+    std::vector<Result> result;
+    Result              r;
+    r.info.gammaAXi     = Id.g;
+    r.info.gammaBXi     = GammaB.g;
+    r.info.gammaASigma  = Id.g;
+    r.info.gammaBSigma  = GammaB.g;
+
+    auto &qqLoop    = envGet(PropagatorField, par().qqLoop);
+    auto &qdSpec    = envGet(SlicedPropagator, par().qdSpec);
+    auto &qdTf      = envGet(PropagatorField, par().qdTf);
+    auto &qsSpec    = envGet(SlicedPropagator, par().qsSpec);
+    auto &qsTi      = envGet(PropagatorField, par().qsTi);
+    auto qdt        = qdSpec[par().tf];
+    auto qst        = qsSpec[par().tf];
+    for (auto &G: Gamma::gall)
+    {
+      r.info.gammaH = G.g;
+      //Operator Q1, equivalent to the two-trace case in the rare-kaons module
+      c=Zero();
+      BaryonUtils<FIMPL>::Xi_to_Sigma_Eye(qqLoop,qdt,qdTf,qst,qsTi,G,GammaB,GammaB,"Q1",c);
+      sliceSum(c,buf,Tp);
+      r.corr.clear();
+      for (unsigned int t = 0; t < buf.size(); ++t)
+      {
+          r.corr.push_back(buf[t]);
+      }
+      r.info.trace = 2;
+      result.push_back(r);
+      //Operator Q2, equivalent to the one-trace case in the rare-kaons module
+      c=Zero();
+      BaryonUtils<FIMPL>::Xi_to_Sigma_Eye(qqLoop,qdt,qdTf,qst,qsTi,G,GammaB,GammaB,"Q2",c);
+      sliceSum(c,buf,Tp);
+      r.corr.clear();
+      for (unsigned int t = 0; t < buf.size(); ++t)
+      {
+          r.corr.push_back(buf[t]);
+      }
+      r.info.trace = 1;
+      result.push_back(r);
+    }
+
+    saveResult(par().output, "xtsEye", result);
+
+}
+
+END_MODULE_NAMESPACE
+
+END_HADRONS_NAMESPACE
+
+#endif // Hadrons_MContraction_XiToSigmaEye_hpp_

--- a/Hadrons/modules.inc
+++ b/Hadrons/modules.inc
@@ -18,6 +18,7 @@ modules_cc =\
   Modules/MContraction/WeakEye3pt.cc \
   Modules/MContraction/WeakMesonDecayKl2.cc \
   Modules/MContraction/WeakNonEye3pt.cc \
+  Modules/MContraction/XiToSigmaEye.cc \
   Modules/MDistil/DistilPar.cc \
   Modules/MDistil/DistilVectors.cc \
   Modules/MDistil/LapEvec.cc \
@@ -103,6 +104,7 @@ modules_hpp =\
   Modules/MContraction/WeakEye3pt.hpp \
   Modules/MContraction/WeakMesonDecayKl2.hpp \
   Modules/MContraction/WeakNonEye3pt.hpp \
+  Modules/MContraction/XiToSigmaEye.hpp \
   Modules/MDistil/Distil.hpp \
   Modules/MDistil/DistilPar.hpp \
   Modules/MDistil/DistilVectors.hpp \

--- a/tests/hadrons/Test_xi_to_sigma.cc
+++ b/tests/hadrons/Test_xi_to_sigma.cc
@@ -116,35 +116,30 @@ int main(int argc, char *argv[])
 
     MSink::Smear::Par smearPar;
     smearPar.q="Qpt_l_0";
-    smearPar.sink = "sink_spec";
-    application.createModule<MSink::Smear>("Qpt_u_spec",smearPar);
+    smearPar.sink = "sink_spec_d";
+    application.createModule<MSink::Smear>("Qpt_d_spec",smearPar);
    
+    MSink::Smear::Par smearPar;
+    smearPar.q="Qpt_s_0";
+    smearPar.sink = "sink_spec_s";
+    application.createModule<MSink::Smear>("Qpt_s_spec",smearPar);
 
-    MContraction::SigmaToNucleonEye::Par EyePar;
-    EyePar.output  = "SigmaToNucleon/Eye_u";
+    MContraction::XiToSigmaEye::Par EyePar;
+    EyePar.output  = "XiToSigma/Eye_u";
     EyePar.qqLoop = "Qpt_l_loop";
-    EyePar.quSpec = "Qpt_u_spec";
+    EyePar.qdSpec = "Qpt_d_spec";
     EyePar.qdTf   = "Qpt_l_4";
+    EyePar.qsSpec = "Qpt_s_spec";
     EyePar.qsTi   = "Qpt_s_0";
     EyePar.tf    = 4;
     EyePar.sink    = "sink";
-    application.createModule<MContraction::SigmaToNucleonEye>("SigmaToNucleonEye_u", EyePar);
-    EyePar.output  = "SigmaToNucleon/Eye_c";
+    application.createModule<MContraction::XiToSigmaEye>("XiToSigmaEye_u", EyePar);
+    EyePar.output  = "XiToSigma/Eye_c";
     EyePar.qqLoop = "Qpt_c_loop";
-    application.createModule<MContraction::SigmaToNucleonEye>("SigmaToNucleonEye_c", EyePar);
-    MContraction::SigmaToNucleonNonEye::Par NonEyePar;
-    NonEyePar.output  = "SigmaToNucleon/NonEye";
-    NonEyePar.quTi = "Qpt_l_0";
-    NonEyePar.quTf = "Qpt_l_4";
-    NonEyePar.quSpec = "Qpt_u_spec";
-    NonEyePar.qdTf   = "Qpt_l_4";
-    NonEyePar.qsTi   = "Qpt_s_0";
-    NonEyePar.tf    = 4;
-    NonEyePar.sink    = "sink";
-    application.createModule<MContraction::SigmaToNucleonNonEye>("SigmaToNucleonNonEye", NonEyePar);
+    application.createModule<MContraction::XiToSigmaEye>("XiToSigmaEye_c", EyePar);
 
     // execution
-    application.saveParameterFile("stn.xml");
+    application.saveParameterFile("xts.xml");
     application.run();
     
     // epilogue

--- a/tests/hadrons/Test_xi_to_sigma.cc
+++ b/tests/hadrons/Test_xi_to_sigma.cc
@@ -116,12 +116,10 @@ int main(int argc, char *argv[])
 
     MSink::Smear::Par smearPar;
     smearPar.q="Qpt_l_0";
-    smearPar.sink = "sink_spec_d";
+    smearPar.sink = "sink_spec";
     application.createModule<MSink::Smear>("Qpt_d_spec",smearPar);
-   
-    MSink::Smear::Par smearPar;
     smearPar.q="Qpt_s_0";
-    smearPar.sink = "sink_spec_s";
+    smearPar.sink = "sink_spec";
     application.createModule<MSink::Smear>("Qpt_s_spec",smearPar);
 
     MContraction::XiToSigmaEye::Par EyePar;


### PR DESCRIPTION
Grid code and Hadrons modules for the Xi^- -> Sigma^- + e^+ + e^- decay, similar to the existing code for the \Sigma^+ -> p + e^+ + e^- decay. Only Eye-topologies occur.

There is also a test program for the code.