### PR TITLE
fix regression in tests/core/Test_qed.cc

### DIFF
--- a/tests/core/Test_qed.cc
+++ b/tests/core/Test_qed.cc
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 
       std::cout << GridLogMessage << "Spatial zero-mode norm 2" << std::endl;
       sliceSum(a, zm, grid.Nd() - 1);
-      for (unsigned int t = 0; t < latt_size.size(); ++t)
+      for (unsigned int t = 0; t < latt_size[Tp]; ++t)
       {
         std::cout << GridLogMessage << "t = " << t << " " << std::sqrt(norm2(zm[t])) << std::endl;
       }


### PR DESCRIPTION
In Grid in commit 61d017d0a5ea12e3798b759af7d9b4c5acdbb13c, the type of GlobalDimensions() was changed to AcceleratorVector, that does not implement a back() member function.

As a consequence the line
```      for (unsigned int t = 0; t < latt_size.back(); ++t)```
in tests/core/Test_qed.cc could not be compiled anymore. It has been changed to
```      for (unsigned int t = 0; t < latt_size.size(); ++t)```
which modifies the behaviour of the function.

This pull request will restore the old, correct behaviour.

A similar pull request is submitted to fix Hadrons' Hadrons/DilutedNoise.hpp. Originally I observed that the number of noises MNoise::TimeDilutedSpinColorDiagonal computes has changed. I then found this change by searching through the commit diff.