### PR TITLE
configure fix for nvcc with extra arguments as CXX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,12 +274,20 @@ case ${ac_gen_scalar} in
 esac
 
 ##################### Compiler dependent choices
-case ${CXX} in 
+
+#Strip any optional compiler arguments from nvcc call (eg -ccbin) for compiler comparison
+CXXBASE=${CXX}
+CXXTEST=${CXX}
+if echo "${CXX}" | grep -q "nvcc"; then
+  CXXTEST="nvcc"
+fi   
+
+case ${CXXTEST} in 
   nvcc) 
 #    CXX="nvcc -keep -v -x cu "
 #    CXXLD="nvcc -v -link"
-    CXX="nvcc -x cu "
-    CXXLD="nvcc -link"
+    CXX="${CXXBASE} -x cu "
+    CXXLD="${CXXBASE} -link"
 #    CXXFLAGS="$CXXFLAGS -Xcompiler -fno-strict-aliasing -Xcompiler -Wno-unusable-partial-specialization --expt-extended-lambda --expt-relaxed-constexpr"
     CXXFLAGS="$CXXFLAGS -Xcompiler -fno-strict-aliasing --expt-extended-lambda --expt-relaxed-constexpr"
     if test $ac_openmp = yes; then


### PR DESCRIPTION
On my machine the default host compiler of nvcc is g++ and not mpic++, and as a result the linking of Grid applications fails with "undefined reference to ${every MPI function}". The only way to change the host compiler (that I know of) is to use  CXX="nvcc -ccbin mpic++". Unfortunately this breaks Grid configure because the catch for nvcc  "case ${CXX} in nvcc)" (line 277 of configure.ac) doesn't catch the modified compiler call and therefore ends up without the necessary extra arguments for compiling and linking. 

Even manually forcing CXX, CXXLD and CXXFLAGS doesn't work because the default case of the above check adds -fno-strict-aliasing, which is not recognized by nvcc without the prefix -Xcompiler.

In this patch I have added a fix that does a substring search for "nvcc" in CXX and acts accordingly.

