### PR TITLE
Bugfix/et go home

### DIFF
--- a/Grid/serialisation/BaseIO.h
+++ b/Grid/serialisation/BaseIO.h
@@ -87,11 +87,7 @@ namespace Grid {
     template<typename Scalar_, typename Dimensions_, int Options_, typename IndexType>
     struct is_tensor_fixed<Eigen::TensorFixedSize<Scalar_, Dimensions_, Options_, IndexType>>
         : public std::true_type {};
-    template<typename Scalar_, typename Dimensions_, int Options_, typename IndexType,
-              int MapOptions_, template <class> class MapPointer_>
-    struct is_tensor_fixed<Eigen::TensorMap<Eigen::TensorFixedSize<Scalar_, Dimensions_,
-                                            Options_, IndexType>, MapOptions_, MapPointer_>>
-        : public std::true_type {};
+    template<typename T> struct is_tensor_fixed<Eigen::TensorMap<T>> : public std::true_type {};
 
     // Is this a variable-size Eigen tensor
     template<typename T, typename V = void> struct is_tensor_variable : public std::false_type {};

--- a/Grid/serialisation/VectorUtils.h
+++ b/Grid/serialisation/VectorUtils.h
@@ -432,12 +432,10 @@ namespace Grid {
   std::vector<T> strToVec(const std::string s)
   {
     std::istringstream sstr(s);
-    T                  buf;
     std::vector<T>     v;
     
-    while(!sstr.eof())
+    for(T buf; sstr >> buf;)
     {
-      sstr >> buf;
       v.push_back(buf);
     }
     


### PR DESCRIPTION
Fix a bug in Eigen Tensor (ET) serialisation.
All TensorMap<...> classes are non-resizable, not just TensorMap<TensorFixedSize> as previously assumed.
NB: This is a pre-requisite for Hadrons Bugfix/ET_go_home