### PR TITLE
Speedup mg kernels

### DIFF
--- a/Grid/algorithms/Algorithms.h
+++ b/Grid/algorithms/Algorithms.h
@@ -62,6 +62,7 @@ Author: Peter Boyle <paboyle@ph.ed.ac.uk>
 #include <Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h>
 #include <Grid/algorithms/iterative/PowerMethod.h>
 
+#include <Grid/algorithms/CoarseningLookupTable.h>
 #include <Grid/algorithms/CoarsenedMatrix.h>
 #include <Grid/algorithms/FFT.h>
 

--- a/Grid/algorithms/CoarsenedMatrix.h
+++ b/Grid/algorithms/CoarsenedMatrix.h
@@ -159,8 +159,9 @@ public:
     for(int i=0;i<nbasis;i++){
       blockProject(iProj,subspace[i],subspace);
       eProj=Zero(); 
+      auto eProj_v = eProj.View();
       accelerator_for(ss, CoarseGrid->oSites(),1,{
-	eProj[ss](i)=CComplex(1.0);
+	eProj_v[ss](i)=CComplex(1.0);
       });
       eProj=eProj - iProj;
       std::cout<<GridLogMessage<<"Orthog check error "<<i<<" " << norm2(eProj)<<std::endl;

--- a/Grid/algorithms/CoarsenedMatrix.h
+++ b/Grid/algorithms/CoarsenedMatrix.h
@@ -145,15 +145,14 @@ public:
   {
   };
   
-  void Orthogonalise(void){
+  void Orthogonalise(int checkOrthogonality = 0, int passes = 1){
     CoarseScalar InnerProd(CoarseGrid); 
-    std::cout << GridLogMessage <<" Block Gramm-Schmidt pass 1"<<std::endl;
-    blockOrthogonalise(InnerProd,subspace);
-    //    std::cout << GridLogMessage <<" Block Gramm-Schmidt pass 2"<<std::endl; // Really have to do twice? Yuck
-    //    blockOrthogonalise(InnerProd,subspace);
-    //      std::cout << GridLogMessage <<" Gramm-Schmidt checking orthogonality"<<std::endl;
-    //      CheckOrthogonal();
-  } 
+    for(int n = 0; n < passes; ++n) {
+      std::cout << GridLogMessage <<" Block Gramm-Schmidt pass "<<n+1<<std::endl;
+      blockOrthogonalise(InnerProd,subspace);
+    }
+    if(checkOrthogonality) CheckOrthogonal();
+  }
   void CheckOrthogonal(void){
     CoarseVector iProj(CoarseGrid); 
     CoarseVector eProj(CoarseGrid); 

--- a/Grid/algorithms/CoarsenedMatrix.h
+++ b/Grid/algorithms/CoarsenedMatrix.h
@@ -696,25 +696,25 @@ public:
 
     //////////////
     // 4D action like wilson
-    // 0+ => 0 
-    // 0- => 1
-    // 1+ => 2 
-    // 1- => 3
+    // 0+ => 0
+    // 0- => 4
+    // 1+ => 1
+    // 1- => 5
     // etc..
     //////////////
     // 5D action like DWF
-    // 1+ => 0 
-    // 1- => 1
-    // 2+ => 2 
-    // 2- => 3
+    // 1+ => 0
+    // 1- => 4
+    // 2+ => 1
+    // 2- => 5
     // etc..
     auto point = [dir, disp, ndim](){
       if(dir == 0 and disp == 0)
 	return 8;
       else if ( ndim==4 ) { 
-	return (4 * dir + 1 - disp) / 2;
+	return (1 - disp) / 2 * 4 + dir;
       } else { 
-	return (4 * (dir-1) + 1 - disp) / 2;
+	return (1 - disp) / 2 * 4 + dir - 1;
       }
     }();
 

--- a/Grid/algorithms/CoarseningLookupTable.h
+++ b/Grid/algorithms/CoarseningLookupTable.h
@@ -1,0 +1,181 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./Grid/algorithms//CoarseningLookupTable.h
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+NAMESPACE_BEGIN(Grid);
+
+class CoarseningLookupTable {
+public:
+
+  /////////////////////////////////////////////
+  // Type Definitions
+  /////////////////////////////////////////////
+
+  typedef uint64_t index_type;
+  typedef uint64_t size_type;
+
+  /////////////////////////////////////////////
+  // Member Data
+  /////////////////////////////////////////////
+
+private:
+  GridBase*                       coarse_;
+  GridBase*                       fine_;
+  bool                            isPopulated_;
+  std::vector<Vector<index_type>> lutVec_;
+  Vector<index_type*>             lutPtr_;
+  Vector<size_type>               sizes_;
+  Vector<index_type>              reverseLutVec_;
+
+  /////////////////////////////////////////////
+  // Member Functions
+  /////////////////////////////////////////////
+
+public:
+  CoarseningLookupTable(GridBase* coarse, GridBase* fine)
+    : coarse_(coarse)
+    , fine_(fine)
+    , isPopulated_(false)
+    , lutVec_(coarse_->oSites())
+    , lutPtr_(coarse_->oSites())
+    , sizes_(coarse_->oSites())
+    , reverseLutVec_(fine_->oSites()) {
+    populate(coarse_, fine_);
+  }
+
+  template<class ScalarField,
+           typename std::enable_if<is_lattice<ScalarField>::value, ScalarField>::type * = nullptr>
+  CoarseningLookupTable(GridBase* coarse, ScalarField const& mask)
+    : coarse_(coarse)
+    , fine_(mask.Grid())
+    , isPopulated_(false)
+    , lutVec_(coarse_->oSites())
+    , lutPtr_(coarse_->oSites())
+    , sizes_(coarse_->oSites())
+    , reverseLutVec_(fine_->oSites()){
+    populate(coarse_, mask);
+  }
+
+  CoarseningLookupTable()
+    : coarse_(nullptr)
+    , fine_(nullptr)
+    , isPopulated_(false)
+    , lutVec_()
+    , lutPtr_()
+    , sizes_()
+    , reverseLutVec_()
+  {}
+
+  // clang-format off
+  accelerator_inline std::vector<Vector<index_type>> const& operator()()  const { return lutVec_; }     // CPU access (TODO: remove?)
+  accelerator_inline index_type const* const*               View()        const { return &lutPtr_[0]; } // GPU access
+  accelerator_inline size_type  const*                      Sizes()       const { return &sizes_[0]; }  // also needed for GPU access
+  accelerator_inline index_type const*                      ReverseView() const { return &reverseLutVec_[0]; }
+  // clang-format on
+
+  bool isPopulated() const { return isPopulated_; }
+
+  bool gridPointersMatch(GridBase* coarse, GridBase* fine) const {
+    // NOTE: This is the same check that "conformable" does
+    return (coarse == coarse_) && (fine == fine_);
+  }
+
+  void setGridPointers(GridBase* coarse, GridBase* fine) {
+    coarse_ = coarse;
+    fine_   = fine;
+  }
+
+  void populate(GridBase* coarse, GridBase* fine) {
+    Lattice<iScalar<vComplex>> fullmask(fine);
+    fullmask = 1.;
+    populate(coarse, fullmask);
+  }
+
+  template<class ScalarField>
+  void populate(GridBase* coarse, ScalarField const& mask) {
+    if(!gridPointersMatch(coarse, mask.Grid())) {
+      setGridPointers(coarse, mask.Grid());
+    }
+
+    int        _ndimension = coarse_->_ndimension;
+    Coordinate block_r(_ndimension);
+
+    size_type block_v = 1;
+    for(int d = 0; d < _ndimension; ++d) {
+      block_r[d] = fine_->_rdimensions[d] / coarse_->_rdimensions[d];
+      assert(block_r[d] * coarse_->_rdimensions[d] == fine_->_rdimensions[d]);
+      block_v *= block_r[d];
+    }
+    assert(block_v == fine_->oSites()/coarse_->oSites());
+
+    lutVec_.resize(coarse_->oSites());
+    lutPtr_.resize(coarse_->oSites());
+    sizes_.resize(coarse_->oSites());
+    reverseLutVec_.resize(fine_->oSites());
+    for(index_type sc = 0; sc < coarse_->oSites(); ++sc) {
+      lutVec_[sc].resize(0);
+      lutVec_[sc].reserve(block_v);
+      lutPtr_[sc] = &lutVec_[sc][0];
+      sizes_[sc]  = 0;
+    }
+
+    typename ScalarField::scalar_type zz = {0., 0.,};
+
+    auto mask_v = mask.View();
+    thread_for(sc, coarse_->oSites(), {
+      Coordinate coor_c(_ndimension);
+      Lexicographic::CoorFromIndex(coor_c, sc, coarse_->_rdimensions);
+
+      int sf_tmp, count = 0;
+      for(int sb = 0; sb < block_v; ++sb) {
+        Coordinate coor_b(_ndimension);
+        Coordinate coor_f(_ndimension);
+
+        Lexicographic::CoorFromIndex(coor_b, sb, block_r);
+        for(int d = 0; d < _ndimension; ++d) coor_f[d] = coor_c[d] * block_r[d] + coor_b[d];
+        Lexicographic::IndexFromCoor(coor_f, sf_tmp, fine_->_rdimensions);
+
+        index_type sf = (index_type)sf_tmp;
+
+        if(Reduce(TensorRemove(coalescedRead(mask_v[sf]))) != zz) {
+          lutPtr_[sc][count] = sf;
+          sizes_[sc]++;
+          count++;
+        }
+        reverseLutVec_[sf] = sc; // reverse table will never have holes
+      }
+      lutVec_[sc].resize(sizes_[sc]);
+    });
+
+    isPopulated_ = true;
+
+    std::cout << GridLogMessage << "Recalculation of coarsening lookup table finished" << std::endl;
+  }
+};
+
+NAMESPACE_END(Grid);

--- a/Grid/lattice/Lattice_base.h
+++ b/Grid/lattice/Lattice_base.h
@@ -530,5 +530,18 @@ template<class vobj> std::ostream& operator<< (std::ostream& stream, const Latti
   return stream;
 }
   
+template<typename vobj>
+Vector<LatticeView<vobj>> getViewContainer(std::vector<Lattice<vobj>>& in) {
+  Vector<LatticeView<vobj>> acceleratorViewContainer;
+  for(int i = 0; i < in.size(); ++i) acceleratorViewContainer.push_back(in[i].View());
+  return acceleratorViewContainer;
+}
+template<typename vobj>
+Vector<LatticeView<vobj>> getViewContainer(std::vector<Lattice<vobj>> const& in) {
+  Vector<LatticeView<vobj>> acceleratorViewContainer;
+  for(int i = 0; i < in.size(); ++i) acceleratorViewContainer.push_back(in[i].View());
+  return acceleratorViewContainer;
+}
+
 NAMESPACE_END(Grid);
 

--- a/Grid/qcd/action/fermion/Fermion.h
+++ b/Grid/qcd/action/fermion/Fermion.h
@@ -92,6 +92,13 @@ NAMESPACE_CHECK(Overlap);
 #include <Grid/qcd/action/fermion/WilsonTMFermion5D.h>   
 NAMESPACE_CHECK(WilsonTM5);
 
+///////////////////////////////////////////////////////////////////////////////
+// Multiple right hand sides via 5d support
+///////////////////////////////////////////////////////////////////////////////
+#include <Grid/qcd/action/fermion/WilsonMRHSFermion.h>
+#include <Grid/qcd/action/fermion/WilsonCloverMRHSFermion.h>
+NAMESPACE_CHECK(MRHS);
+
 ////////////////////////////////////////////////////////////////////////////////
 // Move this group to a DWF specific tools/algorithms subdir? 
 ////////////////////////////////////////////////////////////////////////////////
@@ -151,6 +158,44 @@ typedef WilsonCloverFermion<WilsonTwoIndexSymmetricImplD> WilsonCloverTwoIndexSy
 typedef WilsonCloverFermion<WilsonTwoIndexAntiSymmetricImplR> WilsonCloverTwoIndexAntiSymmetricFermionR;
 typedef WilsonCloverFermion<WilsonTwoIndexAntiSymmetricImplF> WilsonCloverTwoIndexAntiSymmetricFermionF;
 typedef WilsonCloverFermion<WilsonTwoIndexAntiSymmetricImplD> WilsonCloverTwoIndexAntiSymmetricFermionD;
+
+// Wilson MRHS fermions
+typedef WilsonMRHSFermion<WilsonImplR> WilsonMRHSFermionR;
+typedef WilsonMRHSFermion<WilsonImplF> WilsonMRHSFermionF;
+typedef WilsonMRHSFermion<WilsonImplD> WilsonMRHSFermionD;
+
+typedef WilsonMRHSFermion<WilsonImplRL> WilsonMRHSFermionRL;
+typedef WilsonMRHSFermion<WilsonImplFH> WilsonMRHSFermionFH;
+typedef WilsonMRHSFermion<WilsonImplDF> WilsonMRHSFermionDF;
+
+typedef WilsonMRHSFermion<WilsonAdjImplR> WilsonAdjMRHSFermionR;
+typedef WilsonMRHSFermion<WilsonAdjImplF> WilsonAdjMRHSFermionF;
+typedef WilsonMRHSFermion<WilsonAdjImplD> WilsonAdjMRHSFermionD;
+
+typedef WilsonMRHSFermion<WilsonTwoIndexSymmetricImplR> WilsonTwoIndexSymmetricMRHSFermionR;
+typedef WilsonMRHSFermion<WilsonTwoIndexSymmetricImplF> WilsonTwoIndexSymmetricMRHSFermionF;
+typedef WilsonMRHSFermion<WilsonTwoIndexSymmetricImplD> WilsonTwoIndexSymmetricMRHSFermionD;
+
+typedef WilsonMRHSFermion<WilsonTwoIndexAntiSymmetricImplR> WilsonTwoIndexAntiSymmetricMRHSFermionR;
+typedef WilsonMRHSFermion<WilsonTwoIndexAntiSymmetricImplF> WilsonTwoIndexAntiSymmetricMRHSFermionF;
+typedef WilsonMRHSFermion<WilsonTwoIndexAntiSymmetricImplD> WilsonTwoIndexAntiSymmetricMRHSFermionD;
+
+// Clover MRHS fermions
+typedef WilsonCloverMRHSFermion<WilsonImplR> WilsonCloverMRHSFermionR;
+typedef WilsonCloverMRHSFermion<WilsonImplF> WilsonCloverMRHSFermionF;
+typedef WilsonCloverMRHSFermion<WilsonImplD> WilsonCloverMRHSFermionD;
+
+typedef WilsonCloverMRHSFermion<WilsonAdjImplR> WilsonCloverAdjMRHSFermionR;
+typedef WilsonCloverMRHSFermion<WilsonAdjImplF> WilsonCloverAdjMRHSFermionF;
+typedef WilsonCloverMRHSFermion<WilsonAdjImplD> WilsonCloverAdjMRHSFermionD;
+
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexSymmetricImplR> WilsonCloverTwoIndexSymmetricMRHSFermionR;
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexSymmetricImplF> WilsonCloverTwoIndexSymmetricMRHSFermionF;
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexSymmetricImplD> WilsonCloverTwoIndexSymmetricMRHSFermionD;
+
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexAntiSymmetricImplR> WilsonCloverTwoIndexAntiSymmetricMRHSFermionR;
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexAntiSymmetricImplF> WilsonCloverTwoIndexAntiSymmetricMRHSFermionF;
+typedef WilsonCloverMRHSFermion<WilsonTwoIndexAntiSymmetricImplD> WilsonCloverTwoIndexAntiSymmetricMRHSFermionD;
 
 // Domain Wall fermions
 typedef DomainWallFermion<WilsonImplR> DomainWallFermionR;

--- a/Grid/qcd/action/fermion/WilsonCloverFermion.h
+++ b/Grid/qcd/action/fermion/WilsonCloverFermion.h
@@ -81,11 +81,7 @@ public:
                                                                  CloverTermEven(&Hgrid),
                                                                  CloverTermOdd(&Hgrid),
                                                                  CloverTermInvEven(&Hgrid),
-                                                                 CloverTermInvOdd(&Hgrid),
-                                                                 CloverTermDagEven(&Hgrid),
-                                                                 CloverTermDagOdd(&Hgrid),
-                                                                 CloverTermInvDagEven(&Hgrid),
-                                                                 CloverTermInvDagOdd(&Hgrid)
+                                                                 CloverTermInvOdd(&Hgrid)
   {
     assert(Nd == 4); // require 4 dimensions
 
@@ -122,6 +118,10 @@ public:
   virtual void MeeDeriv(GaugeField &mat, const FermionField &U, const FermionField &V, int dag);
 
   void ImportGauge(const GaugeField &_Umu);
+
+  CloverFieldType const* GetCompatibleCloverField(const FermionField &in, int inv);
+  void MultClovInternal(const CloverFieldType &clov, int Ls, int Nsite, const FermionField &in, FermionField &out);
+  void MultClovDagInternal(const CloverFieldType &clov, int Ls, int Nsite, const FermionField &in, FermionField &out);
 
   // Derivative parts unpreconditioned pseudofermions
   void MDeriv(GaugeField &force, const FermionField &X, const FermionField &Y, int dag)
@@ -254,8 +254,7 @@ private:
   CloverFieldType CloverTerm, CloverTermInv;                 // Clover term
   CloverFieldType CloverTermEven, CloverTermOdd;             // Clover term EO
   CloverFieldType CloverTermInvEven, CloverTermInvOdd;       // Clover term Inv EO
-  CloverFieldType CloverTermDagEven, CloverTermDagOdd;       // Clover term Dag EO
-  CloverFieldType CloverTermInvDagEven, CloverTermInvDagOdd; // Clover term Inv Dag EO
+
 
   // eventually these can be compressed into 6x6 blocks instead of the 12x12
   // using the DeGrand-Rossi basis for the gamma matrices

--- a/Grid/qcd/action/fermion/WilsonCloverMRHSFermion.h
+++ b/Grid/qcd/action/fermion/WilsonCloverMRHSFermion.h
@@ -1,0 +1,132 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./lib/qcd/action/fermion/WilsonCloverMRHSFermion.h
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+#include <Grid/qcd/action/fermion/WilsonCloverFermion.h>
+#include <Grid/qcd/action/fermion/WilsonMRHSFermion.h>
+
+NAMESPACE_BEGIN(Grid);
+
+template<class Impl>
+class WilsonCloverMRHSFermion : public WilsonMRHSFermion<Impl>, public WilsonCloverFermion<Impl>
+{
+public:
+  INHERIT_IMPL_TYPES(Impl);
+  typedef WilsonMRHSFermion<Impl> WilsonMRHSBase;
+  typedef WilsonCloverFermion<Impl> WilsonCloverBase;
+  typedef typename WilsonCloverBase::SiteCloverType SiteCloverType;
+  typedef typename WilsonCloverBase::CloverFieldType CloverFieldType;
+
+  virtual void Instantiatable(void){};
+
+  WilsonCloverMRHSFermion(GaugeField                         &_Umu,
+                          GridCartesian                      &FiveDimGrid,
+                          GridRedBlackCartesian              &FiveDimRedBlackGrid,
+                          GridCartesian                      &FourDimGrid,
+                          GridRedBlackCartesian              &FourDimRedBlackGrid,
+                          RealD                               _mass,
+                          RealD                               _csw_r = 0.,
+                          RealD                               _csw_t = 0.,
+                          const WilsonAnisotropyCoefficients &clover_anisotropy = WilsonAnisotropyCoefficients(),
+                          const ImplParams                   &p = ImplParams())
+    : WilsonMRHSBase(_Umu,
+                     FiveDimGrid,
+                     FiveDimRedBlackGrid,
+                     FourDimGrid,
+                     FourDimRedBlackGrid,
+                     _mass,
+                     p)
+    , WilsonCloverBase(_Umu,
+                       FourDimGrid,
+                       FourDimRedBlackGrid,
+                       _mass,
+                       _csw_r,
+                       _csw_t,
+                       clover_anisotropy,
+                       p)
+  {}
+
+  using WilsonMRHSBase::Dhop;
+  using WilsonMRHSBase::DhopOE;
+  using WilsonMRHSBase::DhopEO;
+  using WilsonMRHSBase::DhopDir;
+  using WilsonMRHSBase::DhopDirAll;
+  using WilsonMRHSBase::DhopDirComms;
+  using WilsonMRHSBase::DhopDirCalc;
+  using WilsonMRHSBase::Meooe;
+  using WilsonMRHSBase::MeooeDag;
+  using WilsonMRHSBase::Mdir;
+  using WilsonMRHSBase::MdirAll;
+
+  using WilsonCloverBase::Mooee;
+  using WilsonCloverBase::MooeeInv;
+  using WilsonCloverBase::MooeeDag;
+  using WilsonCloverBase::MooeeInvDag;
+
+  virtual void M(const FermionField &in, FermionField &out) {
+    FermionField tmp(out.Grid());
+
+    // Wilson term
+    out.Checkerboard() = in.Checkerboard();
+    Dhop(in, out, DaggerNo);
+
+    // Clover term
+    Mooee(in, tmp);
+
+    out += tmp;
+  }
+
+  virtual void Mdag(const FermionField &in, FermionField &out) {
+    FermionField tmp(out.Grid());
+
+    // Wilson term
+    out.Checkerboard() = in.Checkerboard();
+    Dhop(in, out, DaggerYes);
+
+    // Clover term
+    MooeeDag(in, tmp);
+
+    out += tmp;
+  }
+
+  // emulate behavior in Clover, but do MRHS
+  virtual void MooeeInternal(const FermionField &in, FermionField &out, int dag, int inv) {
+    out.Checkerboard() = in.Checkerboard();
+    assert(in.Checkerboard() == Odd || in.Checkerboard() == Even);
+
+    const CloverFieldType *Clover = WilsonCloverBase::GetCompatibleCloverField(in, inv);
+    assert(Clover != nullptr);
+
+    if(dag == DaggerYes)
+      WilsonCloverBase::MultClovDagInternal(*Clover,this->Ls,Clover->oSites(),in,out);
+    else
+      WilsonCloverBase::MultClovInternal(*Clover,this->Ls,Clover->oSites(),in,out);
+  }
+};
+
+NAMESPACE_END(Grid);

--- a/Grid/qcd/action/fermion/WilsonMRHSFermion.h
+++ b/Grid/qcd/action/fermion/WilsonMRHSFermion.h
@@ -1,0 +1,131 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./lib/qcd/action/fermion/WilsonMRHSFermion.h
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+#include <Grid/qcd/action/fermion/WilsonFermion5D.h>
+
+NAMESPACE_BEGIN(Grid);
+
+template<class Impl>
+class WilsonMRHSFermion : public WilsonFermion5D<Impl>
+{
+public:
+  INHERIT_IMPL_TYPES(Impl);
+  typedef WilsonFermion5D<Impl> WilsonFermion5DBase;
+
+  virtual void Instantiatable(void){};
+
+  WilsonMRHSFermion(GaugeField            &_Umu,
+                    GridCartesian         &FiveDimGrid,
+                    GridRedBlackCartesian &FiveDimRedBlackGrid,
+                    GridCartesian         &FourDimGrid,
+                    GridRedBlackCartesian &FourDimRedBlackGrid,
+                    RealD                 _mass,
+                    const ImplParams      &p = ImplParams())
+    : WilsonFermion5D<Impl>(_Umu,
+                            FiveDimGrid,
+                            FiveDimRedBlackGrid,
+                            FourDimGrid,
+                            FourDimRedBlackGrid,
+                            -_mass,
+                            p)
+    , mass(_mass)
+    , diag_mass(4.0 + mass)
+  {}
+
+  using WilsonFermion5DBase::Dhop;
+  using WilsonFermion5DBase::DhopOE;
+  using WilsonFermion5DBase::DhopEO;
+  using WilsonFermion5DBase::DhopDir;
+  using WilsonFermion5DBase::DhopDirAll;
+  using WilsonFermion5DBase::DhopDirComms;
+  using WilsonFermion5DBase::DhopDirCalc;
+
+  virtual void M(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    Dhop(in, out, DaggerNo);
+    axpy(out, diag_mass, in, out);
+  }
+
+  virtual void Mdag(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    Dhop(in, out, DaggerYes);
+    axpy(out, diag_mass, in, out);
+  }
+
+  virtual void Meooe(const FermionField &in, FermionField &out) {
+    if (in.Checkerboard() == Odd) {
+      DhopEO(in, out, DaggerNo);
+    } else {
+      DhopOE(in, out, DaggerNo);
+    }
+  }
+
+  virtual void Mooee(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    typename FermionField::scalar_type scal(diag_mass);
+    out = scal * in;
+  }
+
+  virtual void MooeeInv(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    out = (1.0/(diag_mass))*in;
+  }
+
+  virtual void MeooeDag(const FermionField &in, FermionField &out) {
+    if (in.Checkerboard() == Odd) {
+      DhopEO(in, out, DaggerYes);
+    } else {
+      DhopOE(in, out, DaggerYes);
+    }
+  }
+
+  virtual void MooeeDag(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    Mooee(in, out);
+  }
+
+  virtual void MooeeInvDag(const FermionField &in, FermionField &out) {
+    out.Checkerboard() = in.Checkerboard();
+    MooeeInv(in,out);
+  }
+
+  virtual void Mdir(const FermionField &in, FermionField &out, int dir, int disp) {
+    DhopDir(in, out, dir+1, disp); // retain conventions of 4d version
+  }
+
+  virtual void MdirAll(const FermionField &in, std::vector<FermionField> &out) {
+    DhopDirAll(in, out);
+  }
+
+private:
+  RealD mass;
+  RealD diag_mass;
+};
+
+NAMESPACE_END(Grid);

--- a/Grid/util/Commandline.h
+++ b/Grid/util/Commandline.h
@@ -1,0 +1,75 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./Grid/util/Commandline.h
+
+    Copyright (C) 2015 - 2020
+
+    Author: Daniel Richtmann <daniel.richtmann@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+NAMESPACE_BEGIN(Grid);
+
+class Commandline {
+public:
+  static int readInt(int* argc, char*** argv, const std::string& option, int defaultValue) {
+    std::string arg;
+    int         ret = defaultValue;
+    if(GridCmdOptionExists(*argv, *argv + *argc, option)) {
+      arg = GridCmdOptionPayload(*argv, *argv + *argc, option);
+      GridCmdOptionInt(arg, ret);
+    }
+    return ret;
+  }
+
+  static Coordinate readCoordinate(int*               argc,
+                                   char***            argv,
+                                   const std::string& option,
+                                   const Coordinate&  defaultValues) {
+    std::string      arg;
+    std::vector<int> ret(defaultValues.toVector());
+    if(GridCmdOptionExists(*argv, *argv + *argc, option)) {
+      arg = GridCmdOptionPayload(*argv, *argv + *argc, option);
+      GridCmdOptionIntVector(arg, ret);
+    }
+    return ret;
+  }
+
+  static bool readToggle(int* argc, char*** argv, const std::string& option) {
+    return GridCmdOptionExists(*argv, *argv + *argc, option);
+  }
+
+  static std::vector<std::string> readCSL(int*                            argc,
+                                          char***                         argv,
+                                          const std::string&              option,
+                                          const std::vector<std::string>& defaultValues) {
+    std::string              arg;
+    std::vector<std::string> ret(defaultValues);
+    if(GridCmdOptionExists(*argv, *argv + *argc, option)) {
+      arg = GridCmdOptionPayload(*argv, *argv + *argc, option);
+      GridCmdOptionCSL(arg, ret);
+    }
+    return ret;
+  }
+};
+
+NAMESPACE_END(Grid);

--- a/Grid/util/Util.h
+++ b/Grid/util/Util.h
@@ -3,4 +3,5 @@
 #include <Grid/util/Coordinate.h>
 #include <Grid/util/Lexicographic.h>
 #include <Grid/util/Init.h>
+#include <Grid/util/Commandline.h>
 #endif

--- a/benchmarks/Benchmark_blocking_operators.cc
+++ b/benchmarks/Benchmark_blocking_operators.cc
@@ -1,0 +1,279 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./benchmarks/Benchmark_blocking_operators.cc
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+    *************************************************************************************/
+/*  END LEGAL */
+
+#include <Grid/Grid.h>
+#include <Benchmark_helpers.h>
+
+using namespace Grid;
+
+#ifndef NBASIS
+#define NBASIS 40
+#endif
+
+template<class CComplex, int nbasis>
+void convertLayout(std::vector<Lattice<CComplex>> const& in, Lattice<iVector<CComplex, nbasis>>& out) {
+  assert(in.size() == nbasis);
+  for(auto const& elem : in) conformable(elem, out);
+
+  auto  out_v = out.View();
+  auto  in_vc = getViewContainer(in);
+  auto* in_va = &in_vc[0];
+  accelerator_for(ss, out.Grid()->oSites(), CComplex::Nsimd(), {
+    for(int i = 0; i < nbasis; i++) { coalescedWrite(out_v[ss](i), in_va[i](ss)); }
+  });
+}
+
+int main(int argc, char** argv) {
+  Grid_init(&argc, &argv);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                          Read from command line                         //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // clang-format off
+  const int  nBasis    = NBASIS; static_assert((nBasis & 0x1) == 0, "");
+  const int  nB        = nBasis / 2;
+  Coordinate blockSize = Commandline::readCoordinate(&argc, &argv, "--blocksize", Coordinate({4, 4, 4, 4}));
+  uint64_t   nIterMin  = Commandline::readInt(&argc, &argv, "--miniter", 1000);
+  uint64_t   nSecMin   = Commandline::readInt(&argc, &argv, "--minsec", 5);
+  int        Ls        = Commandline::readInt(&argc, &argv, "--Ls", 1);
+  // clang-format on
+
+  std::cout << GridLogMessage << "Compiled with nBasis = " << nBasis << " -> nB = " << nB << std::endl;
+  std::cout << GridLogMessage << "Using Ls = " << Ls << std::endl;
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                              General setup                              //
+  /////////////////////////////////////////////////////////////////////////////
+
+  Coordinate clatt = calcCoarseSize(GridDefaultLatt(), blockSize);
+
+  GridCartesian*         UGrid_f   = SpaceTimeGrid::makeFourDimGrid(GridDefaultLatt(), GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+  GridRedBlackCartesian* UrbGrid_f = SpaceTimeGrid::makeFourDimRedBlackGrid(UGrid_f);
+  GridCartesian*         UGrid_c   = SpaceTimeGrid::makeFourDimGrid(clatt, GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+  GridRedBlackCartesian* UrbGrid_c = SpaceTimeGrid::makeFourDimRedBlackGrid(UGrid_c);
+  GridCartesian*         FGrid_f   = nullptr;
+  GridRedBlackCartesian* FrbGrid_f = nullptr;
+  GridCartesian*         FGrid_c   = nullptr;
+  GridRedBlackCartesian* FrbGrid_c = nullptr;
+
+  if(Ls != 1) {
+    FGrid_f   = SpaceTimeGrid::makeFiveDimGrid(Ls, UGrid_f);
+    FrbGrid_f = SpaceTimeGrid::makeFiveDimRedBlackGrid(Ls, UGrid_f);
+    FGrid_c   = SpaceTimeGrid::makeFiveDimGrid(1, UGrid_c);
+    FrbGrid_c = SpaceTimeGrid::makeFiveDimRedBlackGrid(1, UGrid_c);
+  } else {
+    FGrid_f   = UGrid_f;
+    FrbGrid_f = UrbGrid_f;
+    FGrid_c   = UGrid_c;
+    FrbGrid_c = UrbGrid_c;
+  }
+
+  UGrid_f->show_decomposition();
+  FGrid_f->show_decomposition();
+  UGrid_c->show_decomposition();
+  FGrid_c->show_decomposition();
+
+  GridParallelRNG UPRNG_f(UGrid_f);
+  GridParallelRNG FPRNG_f(FGrid_f);
+  GridParallelRNG UPRNG_c(UGrid_c);
+  GridParallelRNG FPRNG_c(FGrid_c);
+
+  std::vector<int> seeds({1, 2, 3, 4});
+
+  UPRNG_f.SeedFixedIntegers(seeds);
+  FPRNG_f.SeedFixedIntegers(seeds);
+  UPRNG_c.SeedFixedIntegers(seeds);
+  FPRNG_c.SeedFixedIntegers(seeds);
+
+  RealD tol = getPrecision<vComplex>::value == 2 ? 1e-15 : 1e-7;
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                             Type definitions                            //
+  /////////////////////////////////////////////////////////////////////////////
+
+  typedef Aggregation<vSpinColourVector, vTComplex, nBasis>     Aggregates;
+  typedef CoarsenedMatrix<vSpinColourVector, vTComplex, nBasis> CoarseDiracMatrix;
+  typedef CoarseDiracMatrix::CoarseVector                       CoarseFermionField;
+  typedef CoarseDiracMatrix::CoarseMatrix                       CoarseLinkField;
+  typedef CoarseDiracMatrix::FineField::vector_object           Fobj;
+  typedef Lattice<iScalar<vInteger>>                            Coor;
+  typedef Lattice<typename Fobj::tensor_reduced>                FineComplexField;
+  typedef typename Fobj::scalar_type                            ScalarType;
+  typedef CoarseDiracMatrix::CoarseComplexField                 CoarseComplexField;
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                           Setup of Aggregation                          //
+  /////////////////////////////////////////////////////////////////////////////
+
+  const int cb = 0;
+  const int checkOrthog = 1;
+  const int gsPasses = 1;
+
+  Aggregates Aggs(FGrid_c, FGrid_f, cb);
+  Aggs.CreateSubspaceRandom(FPRNG_f);
+  if(Ls != 1) performChiralDoublingG5R5(Aggs.subspace);
+  else        performChiralDoublingG5C(Aggs.subspace);
+  Aggs.Orthogonalise(checkOrthog, gsPasses);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //             Calculate numbers needed for performance figures            //
+  /////////////////////////////////////////////////////////////////////////////
+
+  auto siteElems_f = Ns * Nc;
+  auto siteElems_c = nBasis;
+
+  std::cout << GridLogDebug << "siteElems_f = " << siteElems_f << std::endl;
+  std::cout << GridLogDebug << "siteElems_c = " << siteElems_c << std::endl;
+
+  double UVolume_f = std::accumulate(UGrid_f->_fdimensions.begin(), UGrid_f->_fdimensions.end(), 1, std::multiplies<double>());
+  double FVolume_f = std::accumulate(FGrid_f->_fdimensions.begin(), FGrid_f->_fdimensions.end(), 1, std::multiplies<double>());
+  double UVolume_c = std::accumulate(UGrid_c->_fdimensions.begin(), UGrid_c->_fdimensions.end(), 1, std::multiplies<double>());
+  double FVolume_c = std::accumulate(FGrid_c->_fdimensions.begin(), FGrid_c->_fdimensions.end(), 1, std::multiplies<double>());
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                 Set up stuff required for the benchmark                 //
+  /////////////////////////////////////////////////////////////////////////////
+
+  Geometry geom(FGrid_c->_ndimension);
+
+  std::vector<FineComplexField> masks(geom.npoint, FGrid_f);
+  std::vector<CoarseningLookupTable> lut(geom.npoint);
+
+  { // original setup code taken from CoarsenedMatrix
+    FineComplexField one(FGrid_f); one = ScalarType(1.0, 0.0);
+    FineComplexField zero(FGrid_f); zero = ScalarType(0.0, 0.0);
+    Coor             coor(FGrid_f);
+
+    for(int p=0; p<geom.npoint; ++p) {
+      int     dir   = geom.directions[p];
+      int     disp  = geom.displacements[p];
+      Integer block = (FGrid_f->_rdimensions[dir] / FGrid_c->_rdimensions[dir]);
+
+      LatticeCoordinate(coor, dir);
+
+      if(disp == 0) {
+        masks[p] = Zero();
+      } else if(disp == 1) {
+        masks[p] = where(mod(coor,block) == (block-1), one, zero);
+      } else if(disp == -1) {
+        masks[p] = where(mod(coor,block) == (Integer)0, one, zero);
+      }
+
+      lut[p].populate(FGrid_c, masks[p]);
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                           Start of benchmarks                           //
+  /////////////////////////////////////////////////////////////////////////////
+
+  {
+    std::cout << GridLogMessage << "***************************************************************************" << std::endl;
+    std::cout << GridLogMessage << "Running benchmark for blockMaskedInnerProduct" << std::endl;
+    std::cout << GridLogMessage << "***************************************************************************" << std::endl;
+
+    LatticeFermion src(FGrid_f);
+    std::vector<CoarseComplexField> res_mask(nBasis, FGrid_c);
+    CoarseFermionField res_lut(FGrid_c);
+
+    random(FPRNG_f, src);
+
+    for(int p=0; p<geom.npoint; ++p) {
+      res_lut = Zero();
+      for(auto& elem : res_mask) elem = Zero();
+
+      auto workSites_f = real(TensorRemove(sum(masks[p]))); // remove sites with zero in its mask from flop and byte counting
+
+      std::cout << GridLogMessage << "point = " << p << ": workSites, volume, ratio = " << workSites_f << ", "
+                << FVolume_f << ", " << workSites_f / FVolume_f << std::endl;
+
+      double flop = workSites_f * (8 * siteElems_f) * nBasis;
+      double byte = workSites_f * (2 * 1 + 2 * siteElems_f) * nBasis * sizeof(Complex);
+
+      BenchmarkFunctionMRHS(blockMaskedInnerProduct,
+                            flop, byte, nIterMin, nSecMin, nBasis,
+                            res_mask[rhs], masks[p], Aggs.subspace[rhs], src);
+
+      BenchmarkFunction(blockLutedInnerProduct,
+                        flop, byte, nIterMin, nSecMin,
+                        res_lut, src, Aggs.subspace, lut[p]);
+
+      if(p != geom.npoint-1) { // does nothing for self stencil point
+        CoarseFermionField tmp_lut(FGrid_c);
+        convertLayout(res_mask, tmp_lut);
+        assertResultMatchesReference(tol, res_lut, tmp_lut);
+      }
+    }
+    std::cout << GridLogMessage << "Results are equal" << std::endl;
+  }
+
+  {
+    std::cout << GridLogMessage << "***************************************************************************" << std::endl;
+    std::cout << GridLogMessage << "Running benchmark for blockProject" << std::endl;
+    std::cout << GridLogMessage << "***************************************************************************" << std::endl;
+
+    LatticeFermion src(FGrid_f);
+    CoarseFermionField res_project(FGrid_c);
+    std::vector<CoarseComplexField> res_mask(nBasis, FGrid_c);
+    CoarseFermionField res_lut(FGrid_c);
+
+    random(FPRNG_f, src);
+
+    res_project = Zero();
+    for(auto& elem : res_mask) elem = Zero();
+    res_lut = Zero();
+
+    FineComplexField      fullMask(FGrid_f); fullMask = ScalarType(1.0, 0.0);
+    CoarseningLookupTable fullLut(FGrid_c, fullMask);
+
+    double flop = FVolume_f * (8 * siteElems_f) * nBasis;
+    double byte = FVolume_f * (2 * 1 + 2 * siteElems_f) * nBasis * sizeof(Complex);
+
+    BenchmarkFunction(blockProject,
+                      flop, byte, nIterMin, nSecMin,
+                      res_project, src, Aggs.subspace);
+
+    BenchmarkFunctionMRHS(blockMaskedInnerProduct,
+                          flop, byte, nIterMin, nSecMin, nBasis,
+                          res_mask[rhs], fullMask, Aggs.subspace[rhs], src);
+
+    BenchmarkFunction(blockLutedInnerProduct,
+                      flop, byte, nIterMin, nSecMin,
+                      res_lut, src, Aggs.subspace, fullLut);
+
+    assertResultMatchesReference(tol, res_project, res_lut);
+    CoarseFermionField tmp_lut(FGrid_c);
+    convertLayout(res_mask, tmp_lut);
+    assertResultMatchesReference(tol, res_lut, tmp_lut);
+
+    std::cout << GridLogMessage << "Results are equal" << std::endl;
+  }
+
+  Grid_finalize();
+}

--- a/benchmarks/Benchmark_helpers.h
+++ b/benchmarks/Benchmark_helpers.h
@@ -1,0 +1,126 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./benchmarks/Benchmark_helpers.h
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+    *************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+NAMESPACE_BEGIN(Grid);
+
+struct PerfNumbers {
+  double seconds_, calls_, intensity_, perf_, traffic_;
+  PerfNumbers(double seconds, double calls, double intensity, double perf, double traffic)
+    : seconds_(seconds), calls_(calls), intensity_(intensity), perf_(perf), traffic_(traffic) {}
+};
+
+inline std::ostream& operator<<(std::ostream& stream, const PerfNumbers& pn) {
+  // clang-format off
+  return stream << std::scientific
+                <<        pn.seconds_   << " s"
+                << " " << pn.calls_     << " x"
+                << " " << pn.intensity_ << " F/B"
+                << " " << pn.perf_      << " F/s"
+                << " " << pn.traffic_   << " B/s";
+  // clang-format on
+}
+
+#define BenchmarkFunction(function, flop, byte, nIterMin, nSecMin, ...) \
+  do { \
+    uint64_t nIterFinal = 1; \
+    if(nIterMin != 1) { \
+      uint64_t nIterInitial = 10; \
+      double t0 = usecond(); \
+      for(uint64_t i = 0; i < nIterInitial; ++i) { \
+        __SSC_START; \
+        function(__VA_ARGS__); \
+        __SSC_STOP; \
+      } \
+      double td  = (usecond()-t0)/1e6; \
+      nIterFinal = std::min(nIterMin, (uint64_t)(nSecMin*nIterInitial/td)+1); \
+    } \
+    double t0 = usecond(); \
+    for(uint64_t i = 0; i < nIterFinal; ++i) { \
+      __SSC_START; \
+      function(__VA_ARGS__); \
+      __SSC_STOP; \
+    } \
+    double td = (usecond()-t0)/1e6; \
+    PerfNumbers pn(td, nIterFinal, (byte == 0. ? 0. : flop/byte), flop*nIterFinal/td, byte*nIterFinal/td); \
+    std::cout << GridLogPerformance << "Kernel : " #function << " : " << pn << std::endl; \
+  } while(0)
+
+#define BenchmarkFunctionMRHS(function, flop, byte, nIterMin, nSecMin, nRHS, ...) \
+  do { \
+    uint64_t nIterFinal = 1; \
+    if(nIterMin != 1) { \
+      uint64_t nIterInitial = 10; \
+      double t0 = usecond(); \
+      for(uint64_t i = 0; i < nIterInitial; ++i) { \
+        for(uint64_t rhs = 0; rhs < nRHS; ++rhs) { \
+          __SSC_START; \
+          function(__VA_ARGS__); \
+          __SSC_STOP; \
+        } \
+      } \
+      double td  = (usecond()-t0)/1e6; \
+      nIterFinal = std::min(nIterMin, (uint64_t)(nSecMin*nIterInitial/td)+1); \
+    } \
+    double t0 = usecond(); \
+    for(uint64_t i = 0; i < nIterFinal; ++i) { \
+      for(uint64_t rhs = 0; rhs < nRHS; ++rhs) { \
+        __SSC_START; \
+        function(__VA_ARGS__); \
+        __SSC_STOP; \
+      } \
+    } \
+    double td = (usecond()-t0)/1e6; \
+    PerfNumbers pn(td, nIterFinal, (byte == 0. ? 0. : flop/byte), flop*nIterFinal/td, byte*nIterFinal/td); \
+    std::cout << GridLogPerformance << "Kernel : " #function << " : " << pn << std::endl; \
+  } while(0)
+
+template<class Field>
+void assertResultMatchesReference(RealD tolerance, const Field &reference, const Field &result) {
+  conformable(reference.Grid(), result.Grid());
+  Field diff(reference.Grid());
+
+  diff        = reference - result;
+  auto absDev = norm2(diff);
+  auto relDev = absDev / norm2(reference);
+
+  std::cout << GridLogMessage
+            << "ref = " << norm2(reference)
+            << " res = " << norm2(result)
+            << " absolute deviation = " << absDev
+            << " relative deviation = " << relDev;
+
+  if(relDev <= tolerance) {
+    std::cout << " < " << tolerance << " -> check passed" << std::endl;
+  } else {
+    std::cout << " > " << tolerance << " -> check failed" << std::endl;
+  }
+  assert(relDev <= tolerance);
+}
+
+NAMESPACE_END(Grid);

--- a/benchmarks/Benchmark_wilson_clover_mrhs.cc
+++ b/benchmarks/Benchmark_wilson_clover_mrhs.cc
@@ -1,0 +1,771 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./benchmarks/Benchmark_wilson_clover_mrhs.cc
+
+    Copyright (C) 2015 - 2020
+
+Author: Daniel Richtmann <daniel.richtmann@ur.de>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+    *************************************************************************************/
+/*  END LEGAL */
+
+#include <Grid/Grid.h>
+#include <Benchmark_helpers.h>
+
+using namespace Grid;
+
+struct WorkPerSite {
+  double flop;
+  double elem;
+  double word = sizeof(Complex); // good default with possibility to override
+
+  double byte() const { return elem * word; }
+  double intensity() const { return elem == 0. ? 0. : flop/byte(); }
+};
+
+inline double cMatMulFlop(int n) { return ((8 - 2 / (double)n) * n * n); }
+
+#define doComparison(name4d, name5d, vecs4d, vecs5d, tolerance) \
+  do { \
+    GridBase* grid = vecs4d[0].Grid(); \
+    LatticeFermion vec_tmp(grid); vec_tmp.Checkerboard() = vecs4d[0].Checkerboard(); \
+    LatticeFermion diff(grid); \
+    \
+    for(int i = 0; i < nrhs; i++) { \
+      ExtractSlice(vec_tmp, vecs5d, i, 0); \
+      diff = vecs4d[i] - vec_tmp; \
+      auto diff2 = norm2(diff); \
+      std::cout << GridLogMessage << "vector " << i << ": norm2(" << #name4d << "* v) = " << norm2(vecs4d[i]) \
+                << " norm2(" << #name5d << " * v) = " << norm2(vec_tmp) << " diff = " << diff2 << std::endl; \
+      assert(diff2 == 0.); \
+    } \
+  } while(0)
+
+int main(int argc, char** argv) {
+  Grid_init(&argc, &argv);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                          Read from command line                         //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // clang-format off
+  int      nrhs           = Commandline::readInt(&argc, &argv, "--nrhs", 20);
+  uint64_t nIterMin       = Commandline::readInt(&argc, &argv, "--miniter", 1000);
+  uint64_t nSecMin        = Commandline::readInt(&argc, &argv, "--minsec", 5);
+  bool     countPerformed = Commandline::readToggle(&argc, &argv, "--performed"); // calculate performance with actually performed traffic rather than minimum required
+  // clang-format on
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                              General setup                              //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // clang-format off
+  GridCartesian*         UGrid   = SpaceTimeGrid::makeFourDimGrid(GridDefaultLatt(), GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+  GridRedBlackCartesian* UrbGrid = SpaceTimeGrid::makeFourDimRedBlackGrid(UGrid);
+  GridCartesian*         FGrid   = SpaceTimeGrid::makeFiveDimGrid(nrhs, UGrid);
+  GridRedBlackCartesian* FrbGrid = SpaceTimeGrid::makeFiveDimRedBlackGrid(nrhs, UGrid);
+  // clang-format on
+
+  UGrid->show_decomposition();
+  UrbGrid->show_decomposition();
+  FGrid->show_decomposition();
+  FrbGrid->show_decomposition();
+
+  GridParallelRNG UPRNG(UGrid);
+  GridParallelRNG FPRNG(FGrid);
+
+  std::vector<int> seeds({1, 2, 3, 4});
+
+  UPRNG.SeedFixedIntegers(seeds);
+  FPRNG.SeedFixedIntegers(seeds);
+
+  RealD tol = getPrecision<vComplex>::value == 2 ? 1e-15 : 1e-7;
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                    Setup of Dirac Matrix and Operator                   //
+  /////////////////////////////////////////////////////////////////////////////
+
+  LatticeGaugeField Umu(UGrid); SU3::HotConfiguration(UPRNG, Umu);
+
+  RealD mass = 0.5;
+  RealD csw  = 1.0;
+
+  typename WilsonCloverFermionR::ImplParams implParams;
+  WilsonAnisotropyCoefficients              anisParams;
+
+  std::vector<Complex> boundary_phases(Nd, 1.);
+  if(Commandline::readToggle(&argc, &argv, "--antiperiodic")) boundary_phases[Nd - 1] = -1.;
+  implParams.boundary_phases = boundary_phases;
+
+  WilsonFermionR       Dw(Umu, *UGrid, *UrbGrid, mass, implParams, anisParams);
+  WilsonCloverFermionR Dwc(Umu, *UGrid, *UrbGrid, mass, csw, csw, anisParams, implParams);
+
+  WilsonMRHSFermionR       Dw5(Umu, *FGrid, *FrbGrid, *UGrid, *UrbGrid, mass, implParams);
+  WilsonCloverMRHSFermionR Dwc5(Umu, *FGrid, *FrbGrid, *UGrid, *UrbGrid, mass, csw, csw, anisParams, implParams);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //             Calculate numbers needed for performance figures            //
+  /////////////////////////////////////////////////////////////////////////////
+
+  double volumeUGrid   = std::accumulate(UGrid->_fdimensions.begin(),   UGrid->_fdimensions.end(),   1, std::multiplies<double>());
+  double volumeUrbGrid = std::accumulate(UrbGrid->_fdimensions.begin(), UrbGrid->_fdimensions.end(), 1, std::multiplies<double>());
+  double volumeFGrid   = std::accumulate(FGrid->_fdimensions.begin(),   FGrid->_fdimensions.end(),   1, std::multiplies<double>());
+  double volumeFrbGrid = std::accumulate(FrbGrid->_fdimensions.begin(), FrbGrid->_fdimensions.end(), 1, std::multiplies<double>());
+
+  WorkPerSite wilson_dhop, clover_dhop;
+  WorkPerSite wilson_diag, clover_diag;
+  WorkPerSite wilson_diag_necessary, clover_diag_necessary;
+  WorkPerSite wilson_diag_performed, clover_diag_performed;
+  WorkPerSite wilson_dir, clover_dir;
+  WorkPerSite wilson_full, clover_full;
+  WorkPerSite spinor, gaugemat, clovmat, clovmat_packed;
+
+  spinor.elem         = Ns * Nc;
+  gaugemat.elem       = Nc * Nc;
+  clovmat.elem        = spinor.elem * spinor.elem; // full spincolor matrix
+  clovmat_packed.elem = Nhs * (Nc + (Nhs*Nc) * (Nhs*Nc - 1) / 2); // 2 * (6 diag reals (= 3 complex) + 15 complex upper triang)
+
+  wilson_dhop.flop = 8 * spinor.elem + 8*Nhs*cMatMulFlop(Nc) + 7 * (2*spinor.elem); // spin-proj + su3 x 2 half spinors + accum output
+  wilson_dhop.elem = 8 * (gaugemat.elem + spinor.elem) + spinor.elem;
+
+  clover_dhop.flop = wilson_dhop.flop;
+  clover_dhop.elem = wilson_dhop.elem;
+
+  wilson_diag_necessary.flop = 6 * spinor.elem;
+  wilson_diag_performed.flop = 6 * spinor.elem;
+  wilson_diag_necessary.elem = 2 * spinor.elem;
+  wilson_diag_performed.elem = 2 * spinor.elem;
+
+  clover_diag_necessary.flop = 2 * (cMatMulFlop(Nhs*Nc) - 4*Nhs*Nc); // 2 6x6 matmuls - diff between compl mul and real mul on diagonal
+  clover_diag_performed.flop = cMatMulFlop(spinor.elem);             // clovmat x spinor
+
+  clover_diag_necessary.elem = clovmat_packed.elem + 2 * spinor.elem;
+  clover_diag_performed.elem = clovmat.elem + 2 * spinor.elem;
+
+  wilson_dir.flop = spinor.elem + Nhs*cMatMulFlop(Nc); // spin project + su3 x half spinor + TODO reconstruct?
+  wilson_dir.elem = gaugemat.elem + 2 * spinor.elem; // gauge mat + neigh spinor + output spinor
+
+  clover_dir.flop = wilson_dir.flop;
+  clover_dir.elem = wilson_dir.elem;
+
+  if(countPerformed) { // count traffic that is actually performed by the hardware
+    std::cout << GridLogMessage << "Using traffic value that is actually transfered for the full matrices" << std::endl;
+    wilson_diag = wilson_diag_performed;
+    clover_diag = clover_diag_performed;
+
+    wilson_full.flop = wilson_dhop.flop + 8 * spinor.elem; // axpy = 8 flop
+    wilson_full.elem = wilson_dhop.elem + 3 * spinor.elem; // axpy = 3 spinors
+
+    clover_full.flop = clover_dhop.flop + clover_diag.flop + 2 * spinor.elem; // += = 2 flop
+    clover_full.elem = clover_dhop.elem + clover_diag.elem + 3 * spinor.elem; // += = 3 spinors
+  } else { // count minimal traffic that is actually necessary (e.g., don't count the extra traffic for the spinors since it wouldn't be needed in a fused impl for M)
+    std::cout << GridLogMessage << "Using minimal traffic value that is actually necessary for the full matrices" << std::endl;
+    wilson_diag = wilson_diag_necessary;
+    clover_diag = clover_diag_necessary;
+
+    wilson_full.flop = wilson_dhop.flop + wilson_diag.flop;
+    wilson_full.elem = wilson_dhop.elem + wilson_diag.elem - 2*spinor.elem; // only one spinor load + store required, not 2
+
+    clover_full.flop = clover_dhop.flop + clover_diag.flop;
+    clover_full.elem = clover_dhop.elem + clover_diag.elem - 2*spinor.elem; // only one spinor load + store required, not 2
+  }
+
+  // NOTE flop values per site from output of quda's dslash_test binary:
+  // wilson = 1320
+  // mobius = 1320
+  // clover = 1824
+  // twisted-mass = 1392
+  // twisted-clover = 1872
+  // domain-wall-4d = 1320
+  // domain-wall = 1419
+  // clover-hasenbusch-twist = 1824
+
+  // clang-format off
+  std::cout << GridLogPerformance << "4d volume: " << volumeUGrid << std::endl;
+  std::cout << GridLogPerformance << "5d volume: " << volumeFGrid << std::endl;
+  std::cout << GridLogPerformance << "Dw.Dhop flop/site, byte/site, flop/byte: "   << wilson_dhop.flop << " " << wilson_dhop.byte() << " " << wilson_dhop.intensity() << std::endl;
+  std::cout << GridLogPerformance << "Dwc.Dhop flop/site, byte/site, flop/byte: "  << clover_dhop.flop << " " << clover_dhop.byte() << " " << clover_dhop.intensity() << std::endl;
+  std::cout << GridLogPerformance << "Dw.Mdiag flop/site, byte/site, flop/byte: "  << wilson_diag.flop << " " << wilson_diag.byte() << " " << wilson_diag.intensity() << std::endl;
+  std::cout << GridLogPerformance << "Dwc.Mdiag flop/site, byte/site, flop/byte: " << clover_diag.flop << " " << clover_diag.byte() << " " << clover_diag.intensity() << std::endl;
+  std::cout << GridLogPerformance << "Dw.Mdir flop/site, byte/site, flop/byte: "   << wilson_dir.flop  << " " << wilson_dir.byte()  << " " << wilson_dir.intensity()  << std::endl;
+  std::cout << GridLogPerformance << "Dwc.Mdir flop/site, byte/site, flop/byte: "  << clover_dir.flop  << " " << clover_dir.byte()  << " " << clover_dir.intensity()  << std::endl;
+  std::cout << GridLogPerformance << "Dw.M flop/site, byte/site, flop/byte: "      << wilson_full.flop << " " << wilson_full.byte() << " " << wilson_full.intensity() << std::endl;
+  std::cout << GridLogPerformance << "Dwc.M flop/site, byte/site, flop/byte: "     << clover_full.flop << " " << clover_full.byte() << " " << clover_full.intensity() << std::endl;
+  // clang-format on
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                             Setup of vectors                            //
+  /////////////////////////////////////////////////////////////////////////////
+
+  std::vector<LatticeFermion> vecs_src_4d(nrhs, UGrid);
+  std::vector<LatticeFermion> vecs_res_4d(nrhs, UGrid);
+
+  LatticeFermion vecs_src_5d(FGrid);
+  LatticeFermion vecs_res_5d(FGrid);
+
+  for(int rhs=0; rhs<nrhs; rhs++) {
+    random(UPRNG, vecs_src_4d[rhs]);
+    InsertSlice(vecs_src_4d[rhs], vecs_src_5d, rhs, 0);
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                      Benchmarks for Wilson fermions                     //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Wilson hopping term = "dslash" = "Dhop" //////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_dhop.flop;
+    double byte = volumeUGrid * nrhs * wilson_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dw.Dhop,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs], 0);
+
+    BenchmarkFunction(Dw5.Dhop,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d, 0);
+
+    doComparison(Dw.Dhop, Dw5.Dhop, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson half cb hopping term = "Meooe" ////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    std::vector<LatticeFermion> vecs_src_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_src_4d_o(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_o(nrhs, UrbGrid);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      pickCheckerboard(Even, vecs_src_4d_e[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_src_4d_o[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Even, vecs_res_4d_e[rhs], vecs_res_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_res_4d_o[rhs], vecs_res_4d[rhs]);
+    }
+
+    // clang-format off
+    LatticeFermion vecs_src_5d_e(FrbGrid); pickCheckerboard(Even, vecs_src_5d_e, vecs_src_5d);
+    LatticeFermion vecs_src_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_src_5d_o, vecs_src_5d);
+    LatticeFermion vecs_res_5d_e(FrbGrid); pickCheckerboard(Even, vecs_res_5d_e, vecs_res_5d);
+    LatticeFermion vecs_res_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_res_5d_o, vecs_res_5d);
+    // clang-format on
+
+    double flop = volumeUrbGrid * nrhs * wilson_dhop.flop;
+    double byte = volumeUrbGrid * nrhs * wilson_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dw.Meooe,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_e[rhs], vecs_res_4d_o[rhs]);
+    BenchmarkFunctionMRHS(Dw.Meooe,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_o[rhs], vecs_res_4d_e[rhs]);
+
+    BenchmarkFunction(Dw5.Meooe,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_e, vecs_res_5d_o);
+    BenchmarkFunction(Dw5.Meooe,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_o, vecs_res_5d_e);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_e[rhs]);
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_o[rhs]);
+    }
+    setCheckerboard(vecs_res_5d, vecs_res_5d_e);
+    setCheckerboard(vecs_res_5d, vecs_res_5d_o);
+
+    doComparison(Dw.Meooe, Dw5.Meooe, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson half cb hopping term daggered = "MeooeDag" ////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    std::vector<LatticeFermion> vecs_src_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_src_4d_o(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_o(nrhs, UrbGrid);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      pickCheckerboard(Even, vecs_src_4d_e[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_src_4d_o[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Even, vecs_res_4d_e[rhs], vecs_res_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_res_4d_o[rhs], vecs_res_4d[rhs]);
+    }
+
+    // clang-format off
+    LatticeFermion vecs_src_5d_e(FrbGrid); pickCheckerboard(Even, vecs_src_5d_e, vecs_src_5d);
+    LatticeFermion vecs_src_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_src_5d_o, vecs_src_5d);
+    LatticeFermion vecs_res_5d_e(FrbGrid); pickCheckerboard(Even, vecs_res_5d_e, vecs_res_5d);
+    LatticeFermion vecs_res_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_res_5d_o, vecs_res_5d);
+    // clang-format on
+
+    double flop = volumeUrbGrid * nrhs * wilson_dhop.flop;
+    double byte = volumeUrbGrid * nrhs * wilson_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dw.MeooeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_e[rhs], vecs_res_4d_o[rhs]);
+    BenchmarkFunctionMRHS(Dw.MeooeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_o[rhs], vecs_res_4d_e[rhs]);
+
+    BenchmarkFunction(Dw5.MeooeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_e, vecs_res_5d_o);
+    BenchmarkFunction(Dw5.MeooeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_o, vecs_res_5d_e);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_e[rhs]);
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_o[rhs]);
+    }
+    setCheckerboard(vecs_res_5d, vecs_res_5d_e);
+    setCheckerboard(vecs_res_5d, vecs_res_5d_o);
+
+    doComparison(Dw.MeooeDag, Dw5.MeooeDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson diagonal term = "Mooee" ///////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_diag.flop;
+    double byte = volumeUGrid * nrhs * wilson_diag.byte();
+
+    BenchmarkFunctionMRHS(Dw.Mooee,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.Mooee,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.Mooee, Dw5.Mooee, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson diagonal term inverse = "MooeeInv" ////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_diag.flop;
+    double byte = volumeUGrid * nrhs * wilson_diag.byte();
+
+    BenchmarkFunctionMRHS(Dw.MooeeInv,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.MooeeInv,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.MooeeInv, Dw5.MooeeInv, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson diagonal term daggered = "MooeeDag" ///////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_diag.flop;
+    double byte = volumeUGrid * nrhs * wilson_diag.byte();
+
+    BenchmarkFunctionMRHS(Dw.MooeeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.MooeeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.MooeeDag, Dw5.MooeeDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson diagonal term inverse daggered = "MooeeInvDag" ////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_diag.flop;
+    double byte = volumeUGrid * nrhs * wilson_diag.byte();
+
+    BenchmarkFunctionMRHS(Dw.MooeeInvDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.MooeeInvDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.MooeeInvDag, Dw5.MooeeInvDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson directional term = "Mdir" /////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_dir.flop;
+    double byte = volumeUGrid * nrhs * wilson_dir.byte();
+
+    int dir = 1;
+    int disp = +1;
+
+    BenchmarkFunctionMRHS(Dw.Mdir,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs], dir, disp);
+
+    BenchmarkFunction(Dw5.Mdir,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d, dir, disp);
+
+    doComparison(Dw.Mdir, Dw5.Mdir, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson full matrix = "M" /////////////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_full.flop;
+    double byte = volumeUGrid * nrhs * wilson_full.byte();
+
+    BenchmarkFunctionMRHS(Dw.M,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.M,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.M, Dw5.M, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Wilson full matrix daggered = "Mdag" /////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * wilson_full.flop;
+    double byte = volumeUGrid * nrhs * wilson_full.byte();
+
+    BenchmarkFunctionMRHS(Dw.Mdag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dw5.Mdag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dw.Mdag, Dw5.Mdag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                      Benchmarks for Clover fermions                     //
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Clover hopping term = "dslash" = "Dhop" //////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_dhop.flop;
+    double byte = volumeUGrid * nrhs * clover_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dwc.Dhop,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs], 0);
+
+    BenchmarkFunction(Dwc5.Dhop,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d, 0);
+
+    doComparison(Dwc.Dhop, Dwc5.Dhop, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover half cb hopping term = "Meooe" ////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    std::vector<LatticeFermion> vecs_src_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_src_4d_o(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_o(nrhs, UrbGrid);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      pickCheckerboard(Even, vecs_src_4d_e[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_src_4d_o[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Even, vecs_res_4d_e[rhs], vecs_res_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_res_4d_o[rhs], vecs_res_4d[rhs]);
+    }
+
+    // clang-format off
+    LatticeFermion vecs_src_5d_e(FrbGrid); pickCheckerboard(Even, vecs_src_5d_e, vecs_src_5d);
+    LatticeFermion vecs_src_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_src_5d_o, vecs_src_5d);
+    LatticeFermion vecs_res_5d_e(FrbGrid); pickCheckerboard(Even, vecs_res_5d_e, vecs_res_5d);
+    LatticeFermion vecs_res_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_res_5d_o, vecs_res_5d);
+    // clang-format on
+
+    double flop = volumeUrbGrid * nrhs * clover_dhop.flop;
+    double byte = volumeUrbGrid * nrhs * clover_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dwc.Meooe,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_e[rhs], vecs_res_4d_o[rhs]);
+    BenchmarkFunctionMRHS(Dwc.Meooe,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_o[rhs], vecs_res_4d_e[rhs]);
+
+    BenchmarkFunction(Dwc5.Meooe,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_e, vecs_res_5d_o);
+    BenchmarkFunction(Dwc5.Meooe,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_o, vecs_res_5d_e);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_e[rhs]);
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_o[rhs]);
+    }
+    setCheckerboard(vecs_res_5d, vecs_res_5d_e);
+    setCheckerboard(vecs_res_5d, vecs_res_5d_o);
+
+    doComparison(Dwc.Meooe, Dwc5.Meooe, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover half cb hopping term daggered = "MeooeDag" ////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    std::vector<LatticeFermion> vecs_src_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_src_4d_o(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_e(nrhs, UrbGrid);
+    std::vector<LatticeFermion> vecs_res_4d_o(nrhs, UrbGrid);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      pickCheckerboard(Even, vecs_src_4d_e[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_src_4d_o[rhs], vecs_src_4d[rhs]);
+      pickCheckerboard(Even, vecs_res_4d_e[rhs], vecs_res_4d[rhs]);
+      pickCheckerboard(Odd,  vecs_res_4d_o[rhs], vecs_res_4d[rhs]);
+    }
+
+    // clang-format off
+    LatticeFermion vecs_src_5d_e(FrbGrid); pickCheckerboard(Even, vecs_src_5d_e, vecs_src_5d);
+    LatticeFermion vecs_src_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_src_5d_o, vecs_src_5d);
+    LatticeFermion vecs_res_5d_e(FrbGrid); pickCheckerboard(Even, vecs_res_5d_e, vecs_res_5d);
+    LatticeFermion vecs_res_5d_o(FrbGrid); pickCheckerboard(Odd,  vecs_res_5d_o, vecs_res_5d);
+    // clang-format on
+
+    double flop = volumeUrbGrid * nrhs * clover_dhop.flop;
+    double byte = volumeUrbGrid * nrhs * clover_dhop.byte();
+
+    BenchmarkFunctionMRHS(Dwc.MeooeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_e[rhs], vecs_res_4d_o[rhs]);
+    BenchmarkFunctionMRHS(Dwc.MeooeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d_o[rhs], vecs_res_4d_e[rhs]);
+
+    BenchmarkFunction(Dwc5.MeooeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_e, vecs_res_5d_o);
+    BenchmarkFunction(Dwc5.MeooeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d_o, vecs_res_5d_e);
+
+    for(int rhs=0; rhs<nrhs; rhs++) {
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_e[rhs]);
+      setCheckerboard(vecs_res_4d[rhs], vecs_res_4d_o[rhs]);
+    }
+    setCheckerboard(vecs_res_5d, vecs_res_5d_e);
+    setCheckerboard(vecs_res_5d, vecs_res_5d_o);
+
+    doComparison(Dwc.MeooeDag, Dcw5.MeooeDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover diagonal term = "Mooee" ///////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_diag.flop;
+    double byte = volumeUGrid * nrhs * clover_diag.byte();
+
+    BenchmarkFunctionMRHS(Dwc.Mooee,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.Mooee,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.Mooee, Dwc5.Mooee, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover diagonal term inverse = "MooeeInv" ////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_diag.flop;
+    double byte = volumeUGrid * nrhs * clover_diag.byte();
+
+    BenchmarkFunctionMRHS(Dwc.MooeeInv,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.MooeeInv,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.MooeeInv, Dwc5.MooeeInv, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover diagonal term daggered = "MooeeDag" ///////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_diag.flop;
+    double byte = volumeUGrid * nrhs * clover_diag.byte();
+
+    BenchmarkFunctionMRHS(Dwc.MooeeDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.MooeeDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.MooeeDag, Dwc5.MooeeDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover diagonal term inverse daggered = "MooeeInvDag" ////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_diag.flop;
+    double byte = volumeUGrid * nrhs * clover_diag.byte();
+
+    BenchmarkFunctionMRHS(Dwc.MooeeInvDag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.MooeeInvDag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.MooeeInvDag, Dwc5.MooeeInvDag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover directional term = "Mdir" /////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_dir.flop;
+    double byte = volumeUGrid * nrhs * clover_dir.byte();
+
+    int dir = 1;
+    int disp = +1;
+
+    BenchmarkFunctionMRHS(Dwc.Mdir,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs], dir, disp);
+
+    BenchmarkFunction(Dwc5.Mdir,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d, dir, disp);
+
+    doComparison(Dwc.Mdir, Dwc5.Mdir, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover full matrix = "M" /////////////////////////////////////////////////
+
+  {
+    for(int rhs=0; rhs<nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_full.flop;
+    double byte = volumeUGrid * nrhs * clover_full.byte();
+
+    BenchmarkFunctionMRHS(Dwc.M,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.M,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.M, Dwc5.M, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  // Clover full matrix daggered = "Mdag" /////////////////////////////////////
+
+  {
+    for(int rhs = 0; rhs < nrhs; rhs++) vecs_res_4d[rhs] = Zero();
+    vecs_res_5d = Zero();
+
+    double flop = volumeUGrid * nrhs * clover_full.flop;
+    double byte = volumeUGrid * nrhs * clover_full.byte();
+
+    BenchmarkFunctionMRHS(Dwc.Mdag,
+                          flop, byte, nIterMin, nSecMin, nrhs,
+                          vecs_src_4d[rhs], vecs_res_4d[rhs]);
+
+    BenchmarkFunction(Dwc5.Mdag,
+                      flop, byte, nIterMin, nSecMin,
+                      vecs_src_5d, vecs_res_5d);
+
+    doComparison(Dwc.Mdag, Dwc5.Mdag, vecs_res_4d, vecs_res_5d, tol);
+  }
+
+  Grid_finalize();
+}

--- a/tests/Test_chiral_doubling.cc
+++ b/tests/Test_chiral_doubling.cc
@@ -1,0 +1,77 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./tests/Test_chiral_doubling.cc
+
+    Copyright (C) 2015 - 2020
+
+    Author: Daniel Richtmann <daniel.richtmann@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+
+#include <Grid/Grid.h>
+
+using namespace Grid;
+
+int main(int argc, char** argv) {
+  Grid_init(&argc, &argv);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                              General setup                              //
+  /////////////////////////////////////////////////////////////////////////////
+
+  GridCartesian* Grid = SpaceTimeGrid::makeFourDimGrid(GridDefaultLatt(), GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+
+  std::cout << GridLogMessage << "Grid:" << std::endl; Grid->show_decomposition();
+
+  GridParallelRNG pRNG(Grid);
+  std::vector<int> seeds({1, 2, 3, 4});
+  pRNG.SeedFixedIntegers(seeds);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                             The actual tests                            //
+  /////////////////////////////////////////////////////////////////////////////
+
+  const int nBasis = 40;
+  const int nB     = nBasis / 2;
+
+  std::vector<LatticeFermion> basisVecsRef(nB, Grid);
+  std::vector<LatticeFermion> basisVecsRes(nBasis, Grid);
+
+  for(int n=0; n<nB; n++) {
+    random(pRNG, basisVecsRef[n]);
+    basisVecsRes[n] = basisVecsRef[n];
+  }
+
+  performChiralDoublingG5C(basisVecsRes);
+  undoChiralDoublingG5C(basisVecsRes);
+
+  LatticeFermion diff(Grid);
+  for(int n=0; n<nB; n++) {
+    diff       = basisVecsRef[n] - basisVecsRes[n];
+    auto diff2 = norm2(diff);
+    std::cout << Grid::GridLogMessage << "Vector " << n << ", diff = " << diff2 << std::endl;
+    assert(diff2 == 0.);
+  }
+
+  std::cout << Grid::GridLogMessage << "Test passed" << std::endl;
+
+  Grid_finalize();
+}

--- a/tests/Test_coarsening_lookuptable.cc
+++ b/tests/Test_coarsening_lookuptable.cc
@@ -1,0 +1,120 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./tests/Test_coarsening_lookuptable.cc
+
+    Copyright (C) 2015 - 2020
+
+    Author: Daniel Richtmann <daniel.richtmann@gmail.com>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+
+#include <Grid/Grid.h>
+
+using namespace Grid;
+
+void runTest(GridBase* coarse, GridBase* fine) {
+  CoarseningLookupTable lut(coarse, fine);
+
+  typedef CoarseningLookupTable::index_type index_type;
+  typedef CoarseningLookupTable::size_type size_type;
+
+  auto lut_v   = lut.View();
+  auto sizes_v = lut.Sizes();
+  auto rlut_v  = lut.ReverseView();
+
+  for(index_type sc = 0; sc < lut().size(); ++sc) {
+    for(index_type i = 0; i < lut()[sc].size(); ++i) {
+      auto sf_original  = lut()[sc][i];
+      auto sf_ptr       = lut_v[sc][i];
+      auto sc_reverse   = rlut_v[sf_original];
+      auto diff_ptr     = sf_original - sf_ptr;
+      auto diff_reverse = sc - sc_reverse;
+      assert(diff_ptr == 0);
+      assert(diff_reverse == 0);
+      // clang-format off
+      std::cout << GridLogDebug
+                << "sc = "             << sc
+                << ", i = "            << i
+                << ", sf_original = "  << sf_original
+                << ", sf_ptr = "       << sf_ptr
+                << ", diff_ptr = "     << diff_ptr
+                << ", sc_reverse = "   << sc_reverse
+                << ", diff_reverse = " << diff_reverse
+                << std::endl;
+      // clang-format on
+    }
+  }
+
+  std::cout << GridLogMessage << "First test passed" << std::endl;
+
+  accelerator_for(sc, coarse->oSites(), vComplex::Nsimd(), {
+    for(size_type i = 0; i < sizes_v[sc]; ++i) {
+      auto sf = lut_v[sc][i];
+      printf("GPU_ACCESSIBILITY_NORMAL: sc = %lu, i = %lu, sf = %lu\n", sc, i, sf);
+    }
+  });
+
+  std::cout << GridLogMessage << "Second test passed" << std::endl;
+
+  accelerator_for(sf, fine->oSites(), vComplex::Nsimd(), {
+    auto sc = rlut_v[sf];
+    printf("GPU_ACCESSIBILITY_REVERSE: sf = %lu, sc = %lu\n", sf, sc);
+  });
+
+  std::cout << GridLogMessage << "Third test passed" << std::endl;
+}
+
+int main(int argc, char** argv) {
+  Grid_init(&argc, &argv);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                          Read from command line                         //
+  /////////////////////////////////////////////////////////////////////////////
+
+  Coordinate blockSize = Commandline::readCoordinate(&argc, &argv, "--blocksize", Coordinate({2, 2, 2, 2}));
+  int        Ls        = Commandline::readInt(&argc, &argv, "--Ls", 12);
+
+  /////////////////////////////////////////////////////////////////////////////
+  //                              General setup                              //
+  /////////////////////////////////////////////////////////////////////////////
+
+  Coordinate clatt = calcCoarseSize(GridDefaultLatt(), blockSize);
+
+  GridCartesian*         FGrid_4d   = SpaceTimeGrid::makeFourDimGrid(GridDefaultLatt(), GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+  GridCartesian*         CGrid_4d   = SpaceTimeGrid::makeFourDimGrid(clatt, GridDefaultSimd(Nd, vComplex::Nsimd()), GridDefaultMpi());
+  GridCartesian*         FGrid_5d   = SpaceTimeGrid::makeFiveDimGrid(Ls, FGrid_4d);
+  GridCartesian*         CGrid_5d   = SpaceTimeGrid::makeFiveDimGrid(1, CGrid_4d);
+
+  std::cout << GridLogMessage << "FGrid_4d:" << std::endl; FGrid_4d->show_decomposition();
+  std::cout << GridLogMessage << "CGrid_4d:" << std::endl; CGrid_4d->show_decomposition();
+  std::cout << GridLogMessage << "FGrid_5d:" << std::endl; FGrid_5d->show_decomposition();
+  std::cout << GridLogMessage << "CGrid_5d:" << std::endl; CGrid_5d->show_decomposition();
+
+  runTest(CGrid_4d, FGrid_4d);
+
+  std::cout << GridLogMessage << "4d tests passed" << std::endl;
+
+  runTest(CGrid_5d, FGrid_5d);
+
+  std::cout << GridLogMessage << "5d tests passed" << std::endl;
+
+  Grid_finalize();
+}


### PR DESCRIPTION
Hi, this PR contains: 

- 5 instead of 9 point coarsening for the non-hermitian (= Wilson MG) case
- a lookup table for coarsening. Speeds up (for both 4d (Wilson MG) and 5d (HDCR) use cases)
  - `CoarsenOperator` in setup
  - `blockProject` in solve (also yields small speedup for `blockPromote` but not contained in this PR)
- reduction of number of class member fields in clover fermions + generalization for 5d
- multi-rhs versions of wilson and clover fermions (preparing for multi-rhs `CoarsenOperator` in another PR)
- tests + benchmarks for the above

Daniel