### PR TITLE
ScalarImpl.h updates

### DIFF
--- a/Grid/qcd/action/scalar/ScalarImpl.h
+++ b/Grid/qcd/action/scalar/ScalarImpl.h
@@ -38,7 +38,6 @@ public:
 
   static inline void update_field(Field& P, Field& U, double ep) {
     U += P*ep;
-    std::cout << "Field updated. Epsilon = " << std::setprecision(10) << ep << std::endl;
   }
 
   static inline RealD FieldSquareNorm(Field& U) {
@@ -175,14 +174,13 @@ public:
       P *= scale; 
   }
 
-  static inline Field projectForce(Field& P) {return P;}
+  static inline Field projectForce(Field& P) {return Ta(P);}
 
     static inline void update_field(Field &P, Field &U, double ep)
     {
 #ifndef USE_FFT_ACCELERATION
       double t0=usecond(); 
       U += P*ep;
-      std::cout << "Field updated. Epsilon = " << std::setprecision(10) << ep << std::endl;
       double t1=usecond();
       double total_time = (t1-t0)/1e6;
       std::cout << GridLogIntegrator << "Total time for updating field (s)       : " << total_time << std::endl; 

--- a/Grid/qcd/action/scalar/ScalarImpl.h
+++ b/Grid/qcd/action/scalar/ScalarImpl.h
@@ -28,10 +28,9 @@ public:
   typedef Field              PropagatorField;
     
   static inline void generate_momenta(Field& P, GridParallelRNG& pRNG){
-    RealD scale = ::sqrt(HMC_MOMENTUM_DENOMINATOR); 
-    // CPS and UKQCD conventions not yet implemented for U(1) scalars.
+    RealD scale = ::sqrt(HMC_MOMENTUM_DENOMINATOR); // CPS/UKQCD momentum rescaling
     gaussian(pRNG, P);
-    P *= scale;
+    P *= scale; 
   }
 
   static inline Field projectForce(Field& P){return P;}
@@ -150,7 +149,7 @@ public:
 
     static inline void generate_momenta(Field &P, GridParallelRNG &pRNG)
     {
-      RealD scale = ::sqrt(HMC_MOMENTUM_DENOMINATOR); // Being consistent with CPS and UKQCD conventions
+      RealD scale = ::sqrt(HMC_MOMENTUM_DENOMINATOR); // CPS/UKQCD momentum rescaling
 #ifndef USE_FFT_ACCELERATION
     Group::GaussianFundamentalLieAlgebraMatrix(pRNG, P);
     


### PR DESCRIPTION
These changes made in the ScalarImpl.h fix two issues that were plaguing the HMC simulation for scalars:

1 - The UKQCD/CPS momentum rescaling that was implemented in the HMC integrator but not in the momentum heatbath of scalar fields.

2 - The HMC force which was not traceless and thus was causing the field to leave the Lie Algebra manifold for N>2.