### PR TITLE
Format benchmark wilson sweep

### DIFF
--- a/benchmarks/Benchmark_wilson_sweep.cc
+++ b/benchmarks/Benchmark_wilson_sweep.cc
@@ -89,7 +89,7 @@ int main (int argc, char ** argv)
 
 	  std::cout << GridLogMessage;
 	  std::cout << latt_size;
-    std::cout << "\t\t";
+	  std::cout << "\t\t";
 
 	  GridCartesian           Grid(latt_size,simd_layout,mpi_layout);
 	  GridRedBlackCartesian RBGrid(&Grid);

--- a/benchmarks/Benchmark_wilson_sweep.cc
+++ b/benchmarks/Benchmark_wilson_sweep.cc
@@ -89,6 +89,7 @@ int main (int argc, char ** argv)
 
 	  std::cout << GridLogMessage;
 	  std::cout << latt_size;
+    std::cout << "\t\t";
 
 	  GridCartesian           Grid(latt_size,simd_layout,mpi_layout);
 	  GridRedBlackCartesian RBGrid(&Grid);


### PR DESCRIPTION
Current formatting:

```
[...]
Grid : Message : 4.951091 s : [8 8 8 8]4181.63          4239.57                 4272.4          4242.58         
Grid : Message : 11.812822 s : [8 8 8 16]7216.17                7209.74                 7255.16         7259.36         
Grid : Message : 17.827104 s : [8 8 16 16]14176.7               14157.6                 14223.1         14065.7         
Grid : Message : 23.976875 s : [8 16 16 16]28386.5              28033.7                 27963.9         27762.9         
[...]
```

Adding the double tab makes this easier to parse.