### PR TITLE
Fixed compile issues with maxLocalNorm2 for non-scalar lattices

### DIFF
--- a/Grid/lattice/Lattice_reduction.h
+++ b/Grid/lattice/Lattice_reduction.h
@@ -166,11 +166,12 @@ template<class vobj> inline RealD norm2(const Lattice<vobj> &arg){
   ComplexD nrm = innerProduct(arg,arg);
   return real(nrm); 
 }
+
+//The global maximum of the site norm2
 template<class vobj> inline RealD maxLocalNorm2(const Lattice<vobj> &arg)
 {
-  typedef typename vobj::tensor_reduced vscalar;
-  typedef typename vobj::scalar_object  scalar;
-  typedef typename getPrecision<vobj>::real_scalar_type rscalar;
+  typedef typename vobj::tensor_reduced vscalar;  //iScalar<iScalar<.... <vPODtype> > >
+  typedef typename vscalar::scalar_object  scalar;   //iScalar<iScalar<.... <PODtype> > >
 
   Lattice<vscalar> inner = localNorm2(arg);
 

--- a/tests/core/Test_main.cc
+++ b/tests/core/Test_main.cc
@@ -232,12 +232,13 @@ int main(int argc, char **argv) {
       scalar = localNorm2(cVec);
 
       std::cout << "Testing maxLocalNorm2" <<std::endl;
-      for(Integer gsite=0;gsite<Fine.gSites();gsite++){
-
+      
+      LatticeComplex rand_scalar(&Fine);
+      random(FineRNG, rand_scalar);  //uniform [0,1]
+      for(Integer gsite=0;gsite<Fine.gSites();gsite++){ //check on every site independently
+	scalar = rand_scalar;
 	TComplex big(10.0);
 	Coordinate coor;
-
-	random(FineRNG, scalar);
 	Fine.GlobalIndexToGlobalCoor(gsite,coor);
         pokeSite(big,scalar,coor);
 	


### PR DESCRIPTION
maxLocalNorm2 test now reuses the random field