### PR TITLE
Fix inconsistent SIMD option AVX512

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -444,7 +444,7 @@ case ${ax_cv_cxx_compiler_vendor} in
         SIMD_FLAGS='-mavx2 -mfma -mf16c';;
       AVX512)
         AC_DEFINE([AVX512],[1],[AVX512 intrinsics])
-        SIMD_FLAGS='-mavx512f -mavx512pf -mavx512er -mavx512cd';;
+        SIMD_FLAGS='-mavx512f -mavx512cd';;
       SKL)
         AC_DEFINE([AVX512],[1],[AVX512 intrinsics for SkyLake Xeon])
         SIMD_FLAGS='-march=skylake-avx512';;
@@ -498,7 +498,7 @@ case ${ax_cv_cxx_compiler_vendor} in
         SIMD_FLAGS='-march=core-avx2 -xcore-avx2';;
       AVX512)
         AC_DEFINE([AVX512],[1],[AVX512 intrinsics])
-        SIMD_FLAGS='-xcore-avx512';;
+        SIMD_FLAGS='-xcommon-avx512';;
       KNC)
         AC_DEFINE([IMCI],[1],[IMCI Intrinsics for Knights Corner])
         SIMD_FLAGS='';;

--- a/configure.ac
+++ b/configure.ac
@@ -499,6 +499,9 @@ case ${ax_cv_cxx_compiler_vendor} in
       AVX512)
         AC_DEFINE([AVX512],[1],[AVX512 intrinsics])
         SIMD_FLAGS='-xcommon-avx512';;
+      SKL)
+        AC_DEFINE([AVX512],[1],[AVX512 intrinsics])
+        SIMD_FLAGS='-xcore-avx512';;
       KNC)
         AC_DEFINE([IMCI],[1],[IMCI Intrinsics for Knights Corner])
         SIMD_FLAGS='';;


### PR DESCRIPTION
The AVX512 option for --enabled-simd= has been inconsistent so far. I.e. it causes generation for different target CPUs depending on the used compiler.

For Intel C++ Compiler Classic (ICC): Intel Xeon Skylake-SP/X and newer
For Intel ICX (detected as clang), gcc, clang: Intel Xeon Phi x200/x205 (KNL/KNM)

This merge request changes this behavior and only enables common AVX-512 instruction sets for the AVX512 option.

In addition it adds the missing option "SKL" for ICC.

Of course this is only one possibility to fix this inconsistency.
A second option would be to define AVX512 and SKL to both target Intel Xeon Skylake and newer CPUs and use the special target "KNL" for Intel Xeon Phi x200. I.e. not having any option to generate code targeting both Intel Xeon Skylake and Intel Xeon Phi x200 using at least the AVX512F instruction sets.