### PR TITLE
NERSC header create/archive timedate fixes

### DIFF
--- a/Grid/parallelIO/BinaryIO.h
+++ b/Grid/parallelIO/BinaryIO.h
@@ -73,6 +73,26 @@ inline void removeWhitespace(std::string &key)
   key.erase(std::remove_if(key.begin(), key.end(), ::isspace),key.end());
 }
 
+// Trim leading and trailing whitespace from string
+inline void trimWhitespace( std::string &s )
+{
+  if( !s.empty() )
+  {
+    static const std::string WhiteSpace{ " \t\n\r\f\v" }; // per std::isspace
+    std::size_t first{ s.find_first_not_of( WhiteSpace ) };
+    if( first == std::string::npos )
+      s.clear();
+    else
+    {
+      std::size_t OnePastLast{ s.find_last_not_of( WhiteSpace ) + 1 };
+      if( first )
+        s = s.substr( first, OnePastLast - first );
+      else if( OnePastLast != s.length() )
+        s.resize( OnePastLast );
+    }
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Static class holding the parallel IO code
 // Could just use a namespace

--- a/Grid/parallelIO/MetaData.h
+++ b/Grid/parallelIO/MetaData.h
@@ -128,9 +128,11 @@ inline void MachineCharacteristics(FieldMetaData &header)
   std::time_t t = std::time(nullptr);
   std::tm tm_ = *std::localtime(&t);
   std::ostringstream oss; 
-  //      oss << std::put_time(&tm_, "%c %Z");
-  header.creation_date = oss.str();
-  header.archive_date  = header.creation_date;
+  oss << std::put_time(&tm_, "%c %Z");
+  if( header.creation_date.empty() )
+    header.creation_date = oss.str();
+  if( header.archive_date.empty() )
+    header.archive_date  = oss.str();
 
   // What
   struct utsname name;  uname(&name);

--- a/Grid/parallelIO/NerscIO.h
+++ b/Grid/parallelIO/NerscIO.h
@@ -81,7 +81,7 @@ public:
 	std::string key=line.substr(0,eq);
 	std::string val=line.substr(eq+1);
 	removeWhitespace(key);
-	removeWhitespace(val);
+	trimWhitespace(val);
       
 	header[key] = val;
       }


### PR DESCRIPTION
1) Reinstate insertion of creation and archive timedate in MachineCharacteristics component of NERSC header in Grid/parallelIO/MetaData.h ... but only if not already set.
2) In NerscIO::readHeader (NerscIO.h) make sure header values are trimmed of white space at start and end only (otherwise date fields run together becoming ambiguous).