### PR TITLE
bugfix 3D stout smearing

### DIFF
--- a/Grid/qcd/smearing/StoutSmearing.h
+++ b/Grid/qcd/smearing/StoutSmearing.h
@@ -89,11 +89,12 @@ public:
     SmearBase->smear(C, U);
 
     for (int mu = 0; mu < Nd; mu++) {
-      if( mu == OrthogDim )
+      Umu = peekLorentz(U, mu);
+      if( mu == OrthogDim ){
         tmp = 1.0;  // Don't smear in the orthogonal direction
+      }
       else {
         tmp = peekLorentz(C, mu);
-        Umu = peekLorentz(U, mu);
         iq_mu = Ta(
                    tmp *
                    adj(Umu));  // iq_mu = Ta(Omega_mu) to match the signs with the paper


### PR DESCRIPTION
bugfix following Issue #350.

https://github.com/paboyle/Grid/issues/350

I changed this code, adding the orthogDim part to allow 3D stout smearing for distillation. The issue is correct, this is a bug. The mu=3 links of the field were not used in distillation though, so this didn't cause an issue in the data we produced. 

As far as I'm aware, no other code used 3D stout-smearing so far. 4D stout smearing was unaffected, so while it's great that this bug was found, it very likely wasn't an issue in production yet.