### PR TITLE
nvcc: Add -fopenmp to LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -390,6 +390,7 @@ case ${CXXTEST} in
     CXXFLAGS="$CXXFLAGS -Xcompiler -fno-strict-aliasing --expt-extended-lambda --expt-relaxed-constexpr"
     if test $ac_openmp = yes; then
        CXXFLAGS="$CXXFLAGS -Xcompiler -fopenmp"
+       LDFLAGS="$LDFLAGS -Xcompiler -fopenmp"
     fi
     ;;
   hipcc)


### PR DESCRIPTION
Background: For gpt we are using the information provided by grid-config to compile code and link against the Grid library. Probably others who are using Grid as a library do similar stuff.

I.e. we use for compilation:`$(grid-config --cxx) $(grid-config --cxxflags) -c source.cc`
and for linking: `$(grid-config -cxxld) *.o $(grid-config --ldflags) $(grid-config --libs) -lGrid`.

This is currently working for most compilers and architectures. However for nvcc it currently fails to link properly due to missing `-fopenmp` in LDFLAGS.

This PR adds `-Xcompiler -fopenmp` to LDFLAGS to solve this issue.


Note: Somethin similar might be required for hipcc, but I haven't had time yet to test hipcc yet.