### PR TITLE
make message about setdevice consistent with configure script

### DIFF
--- a/Grid/threads/Accelerator.cc
+++ b/Grid/threads/Accelerator.cc
@@ -83,11 +83,11 @@ void acceleratorInit(void)
     printf("AcceleratorCudaInit: using default device \n");
     printf("AcceleratorCudaInit: assume user either uses a) IBM jsrun, or \n");
     printf("AcceleratorCudaInit: b) invokes through a wrapping script to set CUDA_VISIBLE_DEVICES, UCX_NET_DEVICES, and numa binding \n");
-    printf("AcceleratorCudaInit: Configure options --enable-summit, --enable-select-gpu=no \n");
+    printf("AcceleratorCudaInit: Configure options --enable-setdevice=no \n");
   }
 #else
   printf("AcceleratorCudaInit: rank %d setting device to node rank %d\n",world_rank,rank);
-  printf("AcceleratorCudaInit: Configure options --enable-select-gpu=yes \n");
+  printf("AcceleratorCudaInit: Configure options --enable-setdevice=yes \n");
   cudaSetDevice(rank);
 #endif
   if ( world_rank == 0 )  printf("AcceleratorCudaInit: ================================================\n");


### PR DESCRIPTION
Currently when running on a multi-GPU node, Grid prints a message saying that the `--enable-summit` or `--enable-select-gpu` configure flags control this behaviour.

In fact, the only configure option that controls this is `--enable-setdevice`.

This PR alters the message to reflect this.