### PR TITLE
Hdf5 namespace

### DIFF
--- a/Grid/serialisation/Hdf5IO.cc
+++ b/Grid/serialisation/Hdf5IO.cc
@@ -33,7 +33,7 @@
 
 using namespace Grid;
 #ifndef H5_NO_NAMESPACE
-using namespace H5NS;
+using namespace H5NS; // Compile error here? Try adding --enable-cxx to hdf5 configure
 #endif
 
 // Writer implementation ///////////////////////////////////////////////////////

--- a/Grid/serialisation/Hdf5IO.h
+++ b/Grid/serialisation/Hdf5IO.h
@@ -40,10 +40,6 @@
 #include <Grid/tensors/Tensors.h>
 #include "Hdf5Type.h"
 
-#ifndef H5_NO_NAMESPACE
-#define H5NS H5
-#endif
-
 // default thresold above which datasets are used instead of attributes
 #ifndef HDF5_DEF_DATASET_THRES
 #define HDF5_DEF_DATASET_THRES 6u

--- a/Grid/serialisation/Hdf5Type.h
+++ b/Grid/serialisation/Hdf5Type.h
@@ -5,7 +5,9 @@
 #include <complex>
 #include <memory>
 
-#ifndef H5_NO_NAMESPACE
+#ifdef H5_NO_NAMESPACE
+#define H5NS
+#else
 #define H5NS H5
 #endif
 


### PR DESCRIPTION
Make sure H5NS has empty definition if HDF5 built without C++ namespace.

Add comment in Hdf5IO.cc indicating likely source of error using H5NS, i.e. lack of --enable-cxx in hdf5 configure - in case this trips anyone up in the future.