### PR TITLE
use accelerator for setCheckerboard in RHMC

### DIFF
--- a/Grid/qcd/action/pseudofermion/EvenOddSchurDifferentiable.h
+++ b/Grid/qcd/action/pseudofermion/EvenOddSchurDifferentiable.h
@@ -86,8 +86,13 @@ public:
     assert(ForceE.Checkerboard()==Even);
     assert(ForceO.Checkerboard()==Odd);
 
+#if defined(GRID_CUDA) || defined(GRID_HIP)  || defined(GRID_SYCL)
+    acceleratorSetCheckerboard(Force,ForceE);
+    acceleratorSetCheckerboard(Force,ForceO);
+#else
     setCheckerboard(Force,ForceE); 
     setCheckerboard(Force,ForceO);
+#endif
     Force=-Force;
 
     delete forcecb;
@@ -130,8 +135,13 @@ public:
     assert(ForceE.Checkerboard()==Even);
     assert(ForceO.Checkerboard()==Odd);
 
+#if defined(GRID_CUDA) || defined(GRID_HIP)  || defined(GRID_SYCL)
+    acceleratorSetCheckerboard(Force,ForceE);
+    acceleratorSetCheckerboard(Force,ForceO);
+#else
     setCheckerboard(Force,ForceE); 
     setCheckerboard(Force,ForceO);
+#endif
     Force=-Force;
 
     delete forcecb;


### PR DESCRIPTION
This goes some way towards #378. One-flavour RHMC is 10–20% faster with this, and gives identical results (i.e. generated configurations, excluding the header, are bitwise identical).

Things that could potentially be improved:

* I don't understand what the optional `checker_dim_half` parameter to `acceleratorSetCheckerboard` does, so I have left it at the default value.
* In principle I imagine that all calls to `setCheckerboard` could behave the same way; adding a dispatcher function in `Lattice_transfer.h` that implements the code in this PR in a single place, and then replacing all calls to `setCheckerboard` with calls to this new function would achieve this. However, I'm not set up to verify that the other calls to `setCheckerboard` still give correct results after this change, so I took the more conservative approach of just changing what I can confidently claim works.