### PR TITLE
Fix build by removing conflicting fermion instantiations

### DIFF
--- a/Grid/qcd/action/fermion/instantiation/GparityWilsonImplD/CompactWilsonCloverFermionInstantiationGparityWilsonImplD.cc
+++ b/Grid/qcd/action/fermion/instantiation/GparityWilsonImplD/CompactWilsonCloverFermionInstantiationGparityWilsonImplD.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/GparityWilsonImplF/CompactWilsonCloverFermionInstantiationGparityWilsonImplF.cc
+++ b/Grid/qcd/action/fermion/instantiation/GparityWilsonImplF/CompactWilsonCloverFermionInstantiationGparityWilsonImplF.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonAdjImplD/CompactWilsonCloverFermionInstantiationWilsonAdjImplD.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonAdjImplD/CompactWilsonCloverFermionInstantiationWilsonAdjImplD.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonAdjImplF/CompactWilsonCloverFermionInstantiationWilsonAdjImplF.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonAdjImplF/CompactWilsonCloverFermionInstantiationWilsonAdjImplF.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexAntiSymmetricImplD/CompactWilsonCloverFermionInstantiationWilsonTwoIndexAntiSymmetricImplD.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexAntiSymmetricImplD/CompactWilsonCloverFermionInstantiationWilsonTwoIndexAntiSymmetricImplD.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexAntiSymmetricImplF/CompactWilsonCloverFermionInstantiationWilsonTwoIndexAntiSymmetricImplF.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexAntiSymmetricImplF/CompactWilsonCloverFermionInstantiationWilsonTwoIndexAntiSymmetricImplF.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexSymmetricImplD/CompactWilsonCloverFermionInstantiationWilsonTwoIndexSymmetricImplD.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexSymmetricImplD/CompactWilsonCloverFermionInstantiationWilsonTwoIndexSymmetricImplD.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master

--- a/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexSymmetricImplF/CompactWilsonCloverFermionInstantiationWilsonTwoIndexSymmetricImplF.cc
+++ b/Grid/qcd/action/fermion/instantiation/WilsonTwoIndexSymmetricImplF/CompactWilsonCloverFermionInstantiationWilsonTwoIndexSymmetricImplF.cc
@@ -1,1 +1,0 @@
-../CompactWilsonCloverFermionInstantiation.cc.master


### PR DESCRIPTION
I removed conflicting fermion instantiations of the `CompactWilsonCloverFermion` which broke the build of the develop branch. This disables Gparity, TwoIndex and Adjoint variants of the `CompactWilsonCloverFermion` action. In case support for these variants is desired this PR can be considered a temporary fix.

Closes #383 