### PR TITLE
fix: readded Config.h and Version.h to HFILEs in Grid/Makefile.am

### DIFF
--- a/Grid/Makefile.am
+++ b/Grid/Makefile.am
@@ -70,7 +70,7 @@ endif
 lib_LIBRARIES = libGrid.a
 
 CCFILES += $(extra_sources)
-HFILES  += $(extra_headers)
+HFILES  += $(extra_headers) Config.h Version.h
 
 libGrid_a_SOURCES              = $(CCFILES)
 libGrid_adir                   = $(includedir)/Grid


### PR DESCRIPTION
I re-added `Config.h` and `Version.h` to `HFILES` in `Grid/Makefile.am` which were removed in PR #377 but are required to compile for example Hadrons for which all CI builds fail at the moment for this reason.