### PR TITLE
fixed clover warnings

### DIFF
--- a/Grid/qcd/action/fermion/CloverHelpers.h
+++ b/Grid/qcd/action/fermion/CloverHelpers.h
@@ -181,6 +181,7 @@ public:
 
   static GaugeLinkField Cmunu(std::vector<GaugeLinkField> &U, GaugeLinkField &lambda, int mu, int nu) {
     assert(0);
+    return lambda;
   }
 
 };
@@ -425,6 +426,7 @@ public:
 
   static GaugeLinkField Cmunu(std::vector<GaugeLinkField> &U, GaugeLinkField &lambda, int mu, int nu) {
     assert(0);
+    return lambda;
   }
 
 };


### PR DESCRIPTION
This PR eliminates compiler warnings `missing return statement at end of non-void function` which appeared in connection with the recent changes to the clover fermions. I can now compile again without any warnings using nvcc 11.4.