### PR TITLE
Import round 3

### DIFF
--- a/Grid/lattice/Lattice_transfer.h
+++ b/Grid/lattice/Lattice_transfer.h
@@ -855,7 +855,7 @@ void ExtractSliceLocal(Lattice<vobj> &lowDim,const Lattice<vobj> & higherDim,int
 
 
 template<class vobj>
-void Replicate(Lattice<vobj> &coarse,Lattice<vobj> & fine)
+void Replicate(const Lattice<vobj> &coarse,Lattice<vobj> & fine)
 {
   typedef typename vobj::scalar_object sobj;
 

--- a/Grid/qcd/action/gauge/GaugeImplementations.h
+++ b/Grid/qcd/action/gauge/GaugeImplementations.h
@@ -69,6 +69,11 @@ public:
     return PeriodicBC::ShiftStaple(Link,mu);
   }
 
+  //Same as Cshift for periodic BCs
+  static inline GaugeLinkField CshiftLink(const GaugeLinkField &Link, int mu, int shift){
+    return PeriodicBC::CshiftLink(Link,mu,shift);
+  }
+
   static inline bool isPeriodicGaugeField(void) { return true; }
 };
 
@@ -110,6 +115,11 @@ public:
       return PeriodicBC::CovShiftBackward(Link, mu, field);
   }
 
+  //If mu is a conjugate BC direction
+  //Out(x) = U^dag_\mu(x-mu)  | x_\mu != 0
+  //       = U^T_\mu(L-1)  | x_\mu == 0
+  //else
+  //Out(x) = U^dag_\mu(x-mu mod L)
   static inline GaugeLinkField
   CovShiftIdentityBackward(const GaugeLinkField &Link, int mu)
   {
@@ -129,6 +139,13 @@ public:
       return PeriodicBC::CovShiftIdentityForward(Link,mu);
   }
 
+
+  //If mu is a conjugate BC direction
+  //Out(x) = S_\mu(x+mu)  | x_\mu != L-1
+  //       = S*_\mu(x+mu)  | x_\mu == L-1
+  //else
+  //Out(x) = S_\mu(x+mu mod L)
+  //Note: While this is used for Staples it is also applicable for shifting gauge links or gauge transformation matrices
   static inline GaugeLinkField ShiftStaple(const GaugeLinkField &Link, int mu)
   {
     assert(_conjDirs.size() == Nd);
@@ -136,6 +153,27 @@ public:
       return ConjugateBC::ShiftStaple(Link,mu);
     else     
       return PeriodicBC::ShiftStaple(Link,mu);
+  }
+
+  //Boundary-aware C-shift of gauge links / gauge transformation matrices
+  //For conjugate BC direction
+  //shift = 1
+  //Out(x) = U_\mu(x+\hat\mu)  | x_\mu != L-1
+  //       = U*_\mu(0)  | x_\mu == L-1
+  //shift = -1
+  //Out(x) = U_\mu(x-mu)  | x_\mu != 0
+  //       = U*_\mu(L-1)  | x_\mu == 0
+  //else
+  //shift = 1
+  //Out(x) = U_\mu(x+\hat\mu mod L)
+  //shift = -1
+  //Out(x) = U_\mu(x-\hat\mu mod L)
+  static inline GaugeLinkField CshiftLink(const GaugeLinkField &Link, int mu, int shift){
+    assert(_conjDirs.size() == Nd);
+    if(_conjDirs[mu]) 
+      return ConjugateBC::CshiftLink(Link,mu,shift);
+    else     
+      return PeriodicBC::CshiftLink(Link,mu,shift);
   }
 
   static inline void       setDirections(std::vector<int> &conjDirs) { _conjDirs=conjDirs; }

--- a/Grid/qcd/utils/CovariantCshift.h
+++ b/Grid/qcd/utils/CovariantCshift.h
@@ -88,6 +88,12 @@ namespace PeriodicBC {
     return CovShiftBackward(Link,mu,arg);
   }
 
+  //Boundary-aware C-shift of gauge links / gauge transformation matrices
+  template<class gauge> Lattice<gauge>
+  CshiftLink(const Lattice<gauge> &Link, int mu, int shift)
+  {
+    return Cshift(Link, mu, shift);
+  }
 
 }
 
@@ -158,6 +164,9 @@ namespace ConjugateBC {
     //    std::cout<<"Gparity::CovCshiftBackward mu="<<mu<<std::endl;
     return Cshift(tmp,mu,-1);// moves towards positive mu
   }
+
+  //Out(x) = U^dag_\mu(x-mu)  | x_\mu != 0
+  //       = U^T_\mu(L-1)  | x_\mu == 0
   template<class gauge> Lattice<gauge>
   CovShiftIdentityBackward(const Lattice<gauge> &Link, int mu) {
     GridBase *grid = Link.Grid();
@@ -176,6 +185,9 @@ namespace ConjugateBC {
     return Link;
   }
 
+  //Out(x) = S_\mu(x+\hat\mu)  | x_\mu != L-1
+  //       = S*_\mu(0)  | x_\mu == L-1
+  //Note: While this is used for Staples it is also applicable for shifting gauge links or gauge transformation matrices
   template<class gauge> Lattice<gauge>
   ShiftStaple(const Lattice<gauge> &Link, int mu)
   {
@@ -206,6 +218,35 @@ namespace ConjugateBC {
   {
     auto arg = closure(expr);
     return CovShiftBackward(Link,mu,arg);
+  }
+
+  //Boundary-aware C-shift of gauge links / gauge transformation matrices
+  //shift = 1
+  //Out(x) = U_\mu(x+\hat\mu)  | x_\mu != L-1
+  //       = U*_\mu(0)  | x_\mu == L-1
+  //shift = -1
+  //Out(x) = U_\mu(x-mu)  | x_\mu != 0
+  //       = U*_\mu(L-1)  | x_\mu == 0
+  template<class gauge> Lattice<gauge>
+  CshiftLink(const Lattice<gauge> &Link, int mu, int shift)
+  {
+    GridBase *grid = Link.Grid();
+    int Lmu = grid->GlobalDimensions()[mu] - 1;
+
+    Lattice<iScalar<vInteger>> coor(grid);
+    LatticeCoordinate(coor, mu);
+
+    Lattice<gauge> tmp(grid);
+    if(shift == 1){
+      tmp = Cshift(Link, mu, 1);
+      tmp = where(coor == Lmu, conjugate(tmp), tmp);
+      return tmp;
+    }else if(shift == -1){
+      tmp = Link;
+      tmp = where(coor == Lmu, conjugate(tmp), tmp);
+      return Cshift(tmp, mu, -1);
+    }else assert(0 && "Invalid shift value");
+    return tmp; //shuts up the compiler fussing about the return type
   }
 
 }

--- a/Grid/qcd/utils/GaugeFix.h
+++ b/Grid/qcd/utils/GaugeFix.h
@@ -40,27 +40,46 @@ public:
   typedef typename Gimpl::GaugeLinkField GaugeMat;
   typedef typename Gimpl::GaugeField GaugeLorentz;
 
-  static void GaugeLinkToLieAlgebraField(const std::vector<GaugeMat> &U,std::vector<GaugeMat> &A) {
-    for(int mu=0;mu<Nd;mu++){
-      Complex cmi(0.0,-1.0);
-      A[mu] = Ta(U[mu]) * cmi;
-    }
+  //A_\mu(x) = -i Ta(U_\mu(x) )   where Ta(U) = 1/2( U - U^dag ) - 1/2N tr(U - U^dag)  is the traceless antihermitian part. This is an O(A^3) approximation to the logarithm of U
+  static void GaugeLinkToLieAlgebraField(const GaugeMat &U, GaugeMat &A) {
+    Complex cmi(0.0,-1.0);
+    A = Ta(U) * cmi;
   }
-  static void DmuAmu(const std::vector<GaugeMat> &A,GaugeMat &dmuAmu,int orthog) {
+  
+  //The derivative of the Lie algebra field
+  static void DmuAmu(const std::vector<GaugeMat> &U, GaugeMat &dmuAmu,int orthog) {
+    GridBase* grid = U[0].Grid();
+    GaugeMat Ax(grid);
+    GaugeMat Axm1(grid);
+    GaugeMat Utmp(grid);
+
     dmuAmu=Zero();
     for(int mu=0;mu<Nd;mu++){
       if ( mu != orthog ) {
-	dmuAmu = dmuAmu + A[mu] - Cshift(A[mu],mu,-1);
+	//Rather than define functionality to work out how the BCs apply to A_\mu we simply use the BC-aware Cshift to the gauge links and compute A_\mu(x) and A_\mu(x-1) separately
+	//Ax = A_\mu(x)
+	GaugeLinkToLieAlgebraField(U[mu], Ax);
+	
+	//Axm1 = A_\mu(x_\mu-1)
+	Utmp = Gimpl::CshiftLink(U[mu], mu, -1);
+	GaugeLinkToLieAlgebraField(Utmp, Axm1);
+	
+	//Derivative
+	dmuAmu = dmuAmu + Ax - Axm1;
       }
     }
   }  
 
-  static void SteepestDescentGaugeFix(GaugeLorentz &Umu,Real & alpha,int maxiter,Real Omega_tol, Real Phi_tol,bool Fourier=false,int orthog=-1) {
+  //Fix the gauge field Umu
+  //0 < alpha < 1 is related to the step size, cf https://arxiv.org/pdf/1405.5812.pdf
+  static void SteepestDescentGaugeFix(GaugeLorentz &Umu, Real alpha,int maxiter,Real Omega_tol, Real Phi_tol,bool Fourier=false,int orthog=-1) {
     GridBase *grid = Umu.Grid();
     GaugeMat xform(grid);
     SteepestDescentGaugeFix(Umu,xform,alpha,maxiter,Omega_tol,Phi_tol,Fourier,orthog);
   }
-  static void SteepestDescentGaugeFix(GaugeLorentz &Umu,GaugeMat &xform,Real & alpha,int maxiter,Real Omega_tol, Real Phi_tol,bool Fourier=false,int orthog=-1) {
+
+  //Fix the gauge field Umu and also return the gauge transformation from the original gauge field, xform
+  static void SteepestDescentGaugeFix(GaugeLorentz &Umu,GaugeMat &xform, Real alpha,int maxiter,Real Omega_tol, Real Phi_tol,bool Fourier=false,int orthog=-1) {
 
     GridBase *grid = Umu.Grid();
 
@@ -122,27 +141,24 @@ public:
 
       }
     }
+    assert(0 && "Gauge fixing did not converge within the specified number of iterations");
   };
-  static Real SteepestDescentStep(std::vector<GaugeMat> &U,GaugeMat &xform,Real & alpha, GaugeMat & dmuAmu,int orthog) {
+  static Real SteepestDescentStep(std::vector<GaugeMat> &U,GaugeMat &xform, Real alpha, GaugeMat & dmuAmu,int orthog) {
     GridBase *grid = U[0].Grid();
 
-    std::vector<GaugeMat> A(Nd,grid);
     GaugeMat g(grid);
-
-    GaugeLinkToLieAlgebraField(U,A);
-    ExpiAlphaDmuAmu(A,g,alpha,dmuAmu,orthog);
-
+    ExpiAlphaDmuAmu(U,g,alpha,dmuAmu,orthog);
 
     Real vol = grid->gSites();
     Real trG = TensorRemove(sum(trace(g))).real()/vol/Nc;
 
     xform = g*xform ;
-    SU<Nc>::GaugeTransform(U,g);
+    SU<Nc>::GaugeTransform<Gimpl>(U,g);
 
     return trG;
   }
 
-  static Real FourierAccelSteepestDescentStep(std::vector<GaugeMat> &U,GaugeMat &xform,Real & alpha, GaugeMat & dmuAmu,int orthog) {
+  static Real FourierAccelSteepestDescentStep(std::vector<GaugeMat> &U,GaugeMat &xform, Real alpha, GaugeMat & dmuAmu,int orthog) {
 
     GridBase *grid = U[0].Grid();
 
@@ -157,11 +173,7 @@ public:
 
     GaugeMat g(grid);
     GaugeMat dmuAmu_p(grid);
-    std::vector<GaugeMat> A(Nd,grid);
-
-    GaugeLinkToLieAlgebraField(U,A);
-
-    DmuAmu(A,dmuAmu,orthog);
+    DmuAmu(U,dmuAmu,orthog);
 
     std::vector<int> mask(Nd,1);
     for(int mu=0;mu<Nd;mu++) if (mu==orthog) mask[mu]=0;
@@ -205,16 +217,16 @@ public:
     Real trG = TensorRemove(sum(trace(g))).real()/vol/Nc;
 
     xform = g*xform ;
-    SU<Nc>::GaugeTransform(U,g);
+    SU<Nc>::GaugeTransform<Gimpl>(U,g);
 
     return trG;
   }
 
-  static void ExpiAlphaDmuAmu(const std::vector<GaugeMat> &A,GaugeMat &g,Real & alpha, GaugeMat &dmuAmu,int orthog) {
+  static void ExpiAlphaDmuAmu(const std::vector<GaugeMat> &U,GaugeMat &g, Real alpha, GaugeMat &dmuAmu,int orthog) {
     GridBase *grid = g.Grid();
     Complex cialpha(0.0,-alpha);
     GaugeMat ciadmam(grid);
-    DmuAmu(A,dmuAmu,orthog);
+    DmuAmu(U,dmuAmu,orthog);
     ciadmam = dmuAmu*cialpha;
     SU<Nc>::taExp(ciadmam,g);
   }  

--- a/Grid/qcd/utils/SUn.h
+++ b/Grid/qcd/utils/SUn.h
@@ -694,32 +694,32 @@ public:
  * Adjoint rep gauge xform
  */
 
-  template<typename GaugeField,typename GaugeMat>
-  static void GaugeTransform( GaugeField &Umu, GaugeMat &g){
+  template<typename Gimpl>
+  static void GaugeTransform(typename Gimpl::GaugeField &Umu, typename Gimpl::GaugeLinkField &g){
     GridBase *grid = Umu.Grid();
     conformable(grid,g.Grid());
 
-    GaugeMat U(grid);
-    GaugeMat ag(grid); ag = adj(g);
+    typename Gimpl::GaugeLinkField U(grid);
+    typename Gimpl::GaugeLinkField ag(grid); ag = adj(g);
 
     for(int mu=0;mu<Nd;mu++){
       U= PeekIndex<LorentzIndex>(Umu,mu);
-      U = g*U*Cshift(ag, mu, 1);
+      U = g*U*Gimpl::CshiftLink(ag, mu, 1); //BC-aware
       PokeIndex<LorentzIndex>(Umu,U,mu);
     }
   }
-  template<typename GaugeMat>
-  static void GaugeTransform( std::vector<GaugeMat> &U, GaugeMat &g){
+  template<typename Gimpl>
+  static void GaugeTransform( std::vector<typename Gimpl::GaugeLinkField> &U, typename Gimpl::GaugeLinkField &g){
     GridBase *grid = g.Grid();
-    GaugeMat ag(grid); ag = adj(g);
+    typename Gimpl::GaugeLinkField ag(grid); ag = adj(g);
     for(int mu=0;mu<Nd;mu++){
-      U[mu] = g*U[mu]*Cshift(ag, mu, 1);
+      U[mu] = g*U[mu]*Gimpl::CshiftLink(ag, mu, 1); //BC-aware
     }
   }
-  template<typename GaugeField,typename GaugeMat>
-  static void RandomGaugeTransform(GridParallelRNG &pRNG, GaugeField &Umu, GaugeMat &g){
+  template<typename Gimpl>
+  static void RandomGaugeTransform(GridParallelRNG &pRNG, typename Gimpl::GaugeField &Umu, typename Gimpl::GaugeLinkField &g){
     LieRandomize(pRNG,g,1.0);
-    GaugeTransform(Umu,g);
+    GaugeTransform<Gimpl>(Umu,g);
   }
 
   // Projects the algebra components a lattice matrix (of dimension ncol*ncol -1 )

--- a/Grid/qcd/utils/WilsonLoops.h
+++ b/Grid/qcd/utils/WilsonLoops.h
@@ -125,6 +125,56 @@ public:
     return sumplaq / vol / faces / Nc; // Nd , Nc dependent... FIXME
   }
 
+  //////////////////////////////////////////////////
+  // sum over all spatial planes of plaquette
+  //////////////////////////////////////////////////
+  static void siteSpatialPlaquette(ComplexField &Plaq,
+                            const std::vector<GaugeMat> &U) {
+    ComplexField sitePlaq(U[0].Grid());
+    Plaq = Zero();
+    for (int mu = 1; mu < Nd-1; mu++) {
+      for (int nu = 0; nu < mu; nu++) {
+        traceDirPlaquette(sitePlaq, U, mu, nu);
+        Plaq = Plaq + sitePlaq;
+      }
+    }
+  }
+
+  ////////////////////////////////////
+  // sum over all x,y,z and over all spatial planes of plaquette
+  //////////////////////////////////////////////////
+  static std::vector<RealD> timesliceSumSpatialPlaquette(const GaugeLorentz &Umu) {
+    std::vector<GaugeMat> U(Nd, Umu.Grid());
+    // inefficient here
+    for (int mu = 0; mu < Nd; mu++) {
+      U[mu] = PeekIndex<LorentzIndex>(Umu, mu);
+    }
+
+    ComplexField Plaq(Umu.Grid());
+
+    siteSpatialPlaquette(Plaq, U);
+    typedef typename ComplexField::scalar_object sobj;
+    std::vector<sobj> Tq;
+    sliceSum(Plaq, Tq, Nd-1);
+
+    std::vector<Real> out(Tq.size());
+    for(int t=0;t<Tq.size();t++) out[t] = TensorRemove(Tq[t]).real();
+    return out;
+  }
+  
+  //////////////////////////////////////////////////
+  // average over all x,y,z and over all spatial planes of plaquette
+  //////////////////////////////////////////////////
+  static std::vector<RealD> timesliceAvgSpatialPlaquette(const GaugeLorentz &Umu) {
+    std::vector<RealD> sumplaq = timesliceSumSpatialPlaquette(Umu);
+    int Lt = Umu.Grid()->FullDimensions()[Nd-1];
+    assert(sumplaq.size() == Lt);
+    double vol = Umu.Grid()->gSites() / Lt;
+    double faces = (1.0 * (Nd - 1)* (Nd - 2)) / 2.0;
+    for(int t=0;t<Lt;t++)
+      sumplaq[t] = sumplaq[t] / vol / faces / Nc; // Nd , Nc dependent... FIXME
+    return sumplaq;
+  }
 
   //////////////////////////////////////////////////
   // average over all x,y,z the temporal loop
@@ -363,11 +413,11 @@ public:
     GaugeMat u = PeekIndex<LorentzIndex>(Umu, mu);  // some redundant copies
     GaugeMat vu = v*u;
       //FS = 0.25*Ta(u*v + Cshift(vu, mu, -1));
-      FS = (u*v + Cshift(vu, mu, -1));
+      FS = (u*v + Gimpl::CshiftLink(vu, mu, -1));
       FS = 0.125*(FS - adj(FS));
   }
 
-  static Real TopologicalCharge(GaugeLorentz &U){
+  static Real TopologicalCharge(const GaugeLorentz &U){
     // 4d topological charge
     assert(Nd==4);
     // Bx = -iF(y,z), By = -iF(z,y), Bz = -iF(x,y)
@@ -388,6 +438,203 @@ public:
     auto Tq = sum(qfield);
     return TensorRemove(Tq).real();
   }
+
+
+  //Clover-leaf Wilson loop combination for arbitrary mu-extent M and nu extent N,  mu >= nu
+  //cf  https://arxiv.org/pdf/hep-lat/9701012.pdf Eq 7  for 1x2 Wilson loop    
+  //Clockwise ordering
+  static void CloverleafMxN(GaugeMat &FS, const GaugeMat &Umu, const GaugeMat &Unu, int mu, int nu, int M, int N){  
+#define Fmu(A) Gimpl::CovShiftForward(Umu, mu, A)
+#define Bmu(A) Gimpl::CovShiftBackward(Umu, mu, A)
+#define Fnu(A) Gimpl::CovShiftForward(Unu, nu, A)
+#define Bnu(A) Gimpl::CovShiftBackward(Unu, nu, A)
+#define FmuI Gimpl::CovShiftIdentityForward(Umu, mu)
+#define BmuI Gimpl::CovShiftIdentityBackward(Umu, mu)
+#define FnuI Gimpl::CovShiftIdentityForward(Unu, nu)
+#define BnuI Gimpl::CovShiftIdentityBackward(Unu, nu)
+
+    //Upper right loop
+    GaugeMat tmp = BmuI;
+    for(int i=1;i<M;i++)
+      tmp = Bmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Bnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Fmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Fnu(tmp);
+      
+    FS = tmp;
+
+    //Upper left loop
+    tmp = BnuI;
+    for(int j=1;j<N;j++)
+      tmp = Bnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Fmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Fnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Bmu(tmp);
+      
+    FS = FS + tmp;
+
+    //Lower right loop
+    tmp = FnuI;
+    for(int j=1;j<N;j++)
+      tmp = Fnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Bmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Bnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Fmu(tmp);
+      
+    FS = FS + tmp;
+
+    //Lower left loop
+    tmp = FmuI;
+    for(int i=1;i<M;i++)
+      tmp = Fmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Fnu(tmp);
+    for(int i=0;i<M;i++)
+      tmp = Bmu(tmp);
+    for(int j=0;j<N;j++)
+      tmp = Bnu(tmp);
+
+    FS = FS + tmp;
+
+#undef Fmu
+#undef Bmu
+#undef Fnu
+#undef Bnu
+#undef FmuI
+#undef BmuI
+#undef FnuI
+#undef BnuI
+  }
+
+  //Field strength from MxN Wilson loop
+  //Note F_numu = - F_munu
+  static void FieldStrengthMxN(GaugeMat &FS, const GaugeLorentz &U, int mu, int nu, int M, int N){  
+    GaugeMat Umu = PeekIndex<LorentzIndex>(U, mu);
+    GaugeMat Unu = PeekIndex<LorentzIndex>(U, nu);
+    if(M == N){
+      GaugeMat F(Umu.Grid());
+      CloverleafMxN(F, Umu, Unu, mu, nu, M, N);
+      FS = 0.125 * ( F - adj(F) );
+    }else{
+      //Average over both orientations
+      GaugeMat horizontal(Umu.Grid()), vertical(Umu.Grid());
+      CloverleafMxN(horizontal, Umu, Unu, mu, nu, M, N);
+      CloverleafMxN(vertical, Umu, Unu, mu, nu, N, M);
+      FS = 0.0625 * ( horizontal - adj(horizontal) + vertical - adj(vertical) );
+    }
+  }
+
+  //Topological charge contribution from MxN Wilson loops
+  //cf  https://arxiv.org/pdf/hep-lat/9701012.pdf  Eq 6
+  //output is the charge by timeslice: sum over timeslices to obtain the total
+  static std::vector<Real> TimesliceTopologicalChargeMxN(const GaugeLorentz &U, int M, int N){
+    assert(Nd == 4);
+    std::vector<std::vector<GaugeMat*> > F(Nd,std::vector<GaugeMat*>(Nd,nullptr));
+    //Note F_numu = - F_munu
+    //hence we only need to loop over mu,nu,rho,sigma that aren't related by permuting mu,nu  or rho,sigma
+    //Use nu > mu
+    for(int mu=0;mu<Nd-1;mu++){
+      for(int nu=mu+1; nu<Nd; nu++){
+	F[mu][nu] = new GaugeMat(U.Grid());
+	FieldStrengthMxN(*F[mu][nu], U, mu, nu, M, N);
+      }
+    }
+    Real coeff = -1./(32 * M_PI*M_PI * M*M * N*N); //overall sign to match CPS and Grid conventions, possibly related to time direction = 3 vs 0
+
+    static const int combs[3][4] = { {0,1,2,3}, {0,2,1,3}, {0,3,1,2} };
+    static const int signs[3] = { 1, -1, 1 }; //epsilon_{mu nu rho sigma}
+
+    ComplexField fsum(U.Grid());
+    fsum = Zero();
+    for(int c=0;c<3;c++){
+      int mu = combs[c][0], nu = combs[c][1], rho = combs[c][2], sigma = combs[c][3];
+      int eps = signs[c];
+      fsum = fsum + (8. * coeff * eps) * trace( (*F[mu][nu]) * (*F[rho][sigma]) ); 
+    }
+
+    for(int mu=0;mu<Nd-1;mu++)
+      for(int nu=mu+1; nu<Nd; nu++)
+	delete F[mu][nu];
+    
+    typedef typename ComplexField::scalar_object sobj;
+    std::vector<sobj> Tq;
+    sliceSum(fsum, Tq, Nd-1);
+
+    std::vector<Real> out(Tq.size());
+    for(int t=0;t<Tq.size();t++) out[t] = TensorRemove(Tq[t]).real();
+    return out;
+  }
+  static Real TopologicalChargeMxN(const GaugeLorentz &U, int M, int N){
+    std::vector<Real> Tq = TimesliceTopologicalChargeMxN(U,M,N);
+    Real out(0);
+    for(int t=0;t<Tq.size();t++) out += Tq[t];
+    return out;
+  }
+
+  //Generate the contributions to the 5Li topological charge from Wilson loops of the following sizes
+  //Use coefficients from hep-lat/9701012
+  //1x1 : c1=(19.-55.*c5)/9.
+  //2x2 : c2=(1-64.*c5)/9.
+  //1x2 : c3=(-64.+640.*c5)/45.
+  //1x3 : c4=1./5.-2.*c5
+  //3x3 : c5=1./20.
+  //Output array outer index contains the loops in the above order
+  //Inner index is the time coordinate
+  static std::vector<std::vector<Real> > TimesliceTopologicalCharge5LiContributions(const GaugeLorentz &U){
+    static const int exts[5][2] = { {1,1}, {2,2}, {1,2}, {1,3}, {3,3} };       
+    std::vector<std::vector<Real> > out(5);
+    for(int i=0;i<5;i++){	
+      out[i] = TimesliceTopologicalChargeMxN(U,exts[i][0],exts[i][1]);
+    }
+    return out;
+  }   
+
+  static std::vector<Real> TopologicalCharge5LiContributions(const GaugeLorentz &U){   
+    static const int exts[5][2] = { {1,1}, {2,2}, {1,2}, {1,3}, {3,3} };
+    std::vector<Real> out(5);
+    std::cout << GridLogMessage << "Computing topological charge" << std::endl;
+    for(int i=0;i<5;i++){
+      out[i] = TopologicalChargeMxN(U,exts[i][0],exts[i][1]);
+      std::cout << GridLogMessage << exts[i][0] << "x" << exts[i][1] << " Wilson loop contribution " << out[i] << std::endl;
+    }
+    return out;
+  }
+
+  //Compute the 5Li topological charge
+  static std::vector<Real> TimesliceTopologicalCharge5Li(const GaugeLorentz &U){
+    std::vector<std::vector<Real> > loops = TimesliceTopologicalCharge5LiContributions(U);
+
+    double c5=1./20.;
+    double c4=1./5.-2.*c5;
+    double c3=(-64.+640.*c5)/45.;
+    double c2=(1-64.*c5)/9.;
+    double c1=(19.-55.*c5)/9.;
+
+    int Lt = loops[0].size();
+    std::vector<Real> out(Lt,0.);
+    for(int t=0;t<Lt;t++)
+      out[t] += c1*loops[0][t] + c2*loops[1][t] + c3*loops[2][t] + c4*loops[3][t] + c5*loops[4][t];
+    return out;
+  }
+
+  static Real TopologicalCharge5Li(const GaugeLorentz &U){
+    std::vector<Real> Qt = TimesliceTopologicalCharge5Li(U);
+    Real Q = 0.;
+    for(int t=0;t<Qt.size();t++) Q += Qt[t];
+    std::cout << GridLogMessage << "5Li Topological charge: " << Q << std::endl;
+    return Q;
+  }
+
+
 
 
   //////////////////////////////////////////////////////

--- a/examples/Example_Laplacian.cc
+++ b/examples/Example_Laplacian.cc
@@ -324,7 +324,7 @@ int main(int argc, char ** argv)
 
   U_GT = U;
   // Make a random xform to teh gauge field
-  SU<Nc>::RandomGaugeTransform(RNG,U_GT,g); // Unit gauge
+  SU<Nc>::RandomGaugeTransform<PeriodicGimplR>(RNG,U_GT,g); // Unit gauge
 
   Field in_GT(&Grid); 
   Field out_GT(&Grid);

--- a/tests/core/Test_fft_gfix.cc
+++ b/tests/core/Test_fft_gfix.cc
@@ -29,14 +29,10 @@ Author: Peter Boyle <paboyle@ph.ed.ac.uk>
 #include <Grid/Grid.h>
 
 using namespace Grid;
- ;
 
-int main (int argc, char ** argv)
-{
+template<typename Gimpl>
+void run(double alpha, bool do_fft_gfix){
   std::vector<int> seeds({1,2,3,4});
-
-  Grid_init(&argc,&argv);
-
   int threads = GridThread::GetThreads();
 
   Coordinate latt_size   = GridDefaultLatt();
@@ -55,10 +51,7 @@ int main (int argc, char ** argv)
   FFT theFFT(&GRID);
 
   std::cout<<GridLogMessage << "Grid is setup to use "<<threads<<" threads"<<std::endl;
-
-  std::cout<< "*****************************************************************" <<std::endl;
-  std::cout<< "* Testing we can gauge fix steep descent a RGT of Unit gauge    *" <<std::endl;
-  std::cout<< "*****************************************************************" <<std::endl;
+  std::cout<<GridLogMessage << "Using alpha=" << alpha << std::endl;
 
   //  int coulomb_dir = -1;
   int coulomb_dir = Nd-1;
@@ -72,81 +65,167 @@ int main (int argc, char ** argv)
   LatticeColourMatrix   xform1(&GRID); // Gauge xform
   LatticeColourMatrix   xform2(&GRID); // Gauge xform
   LatticeColourMatrix   xform3(&GRID); // Gauge xform
+
+  //#########################################################################################
+
+  std::cout<< "*********************************************************************************************************" <<std::endl;
+  std::cout<< "* Testing steepest descent fixing to Landau gauge with randomly transformed unit gauge configuration    *" <<std::endl;
+  std::cout<< "*********************************************************************************************************" <<std::endl;
   
   SU<Nc>::ColdConfiguration(pRNG,Umu); // Unit gauge
   Uorg=Umu;
+
+  Real init_plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Initial plaquette "<< init_plaq << std::endl;
+
+  //Apply a random gauge transformation to the unit gauge config
   Urnd=Umu;
+  SU<Nc>::RandomGaugeTransform<Gimpl>(pRNG,Urnd,g);
 
-  SU<Nc>::RandomGaugeTransform(pRNG,Urnd,g); // Unit gauge
-
-  Real plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Initial plaquette "<<plaq << std::endl;
-
-  Real alpha=0.1;
-
+  //Gauge fix the randomly transformed field 
   Umu = Urnd;
-  FourierAcceleratedGaugeFixer<PeriodicGimplR>::SteepestDescentGaugeFix(Umu,xform1,alpha,10000,1.0e-12, 1.0e-12,false);
+  FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,xform1,alpha,10000,1.0e-12, 1.0e-12,false);
 
   // Check the gauge xform matrices
   Utmp=Urnd;
-  SU<Nc>::GaugeTransform(Utmp,xform1);
+  SU<Nc>::GaugeTransform<Gimpl>(Utmp,xform1);
   Utmp = Utmp - Umu;
-  std::cout << " Norm Difference of xformed gauge "<< norm2(Utmp) << std::endl;
+  std::cout << " Check the output gauge transformation matrices applied to the original field produce the xformed field "<< norm2(Utmp) << " (expect 0)" << std::endl;
   
 
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Final plaquette "<<plaq << std::endl;
+  Real plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
 
   Uorg = Uorg - Umu;
-  std::cout << " Norm Difference "<< norm2(Uorg) << std::endl;
-  std::cout << " Norm "<< norm2(Umu) << std::endl;
+  std::cout << " Norm difference between a unit gauge configuration and the gauge fixed configuration "<< norm2(Uorg) << " (expect 0)" << std::endl;
+  std::cout << " Norm of gauge fixed configuration "<< norm2(Umu) << std::endl;
+
+  //#########################################################################################
+  if(do_fft_gfix){
+    std::cout<< "*************************************************************************************" <<std::endl;
+    std::cout<< "* Testing Fourier accelerated fixing to Landau gauge with unit gauge configuration  *" <<std::endl;
+    std::cout<< "*************************************************************************************" <<std::endl;
+    Umu=Urnd;
+    FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,xform2,alpha,10000,1.0e-12, 1.0e-12,true);
+
+    Utmp=Urnd;
+    SU<Nc>::GaugeTransform<Gimpl>(Utmp,xform2);
+    Utmp = Utmp - Umu;
+    std::cout << " Check the output gauge transformation matrices applied to the original field produce the xformed field "<< norm2(Utmp) << " (expect 0)" << std::endl;
 
 
-  std::cout<< "*****************************************************************" <<std::endl;
-  std::cout<< "* Testing Fourier accelerated fixing                            *" <<std::endl;
-  std::cout<< "*****************************************************************" <<std::endl;
+    plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+    std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
+  }
+  //#########################################################################################
+
+  std::cout<< "******************************************************************************************" <<std::endl;
+  std::cout<< "* Testing steepest descent fixing to Landau gauge with random configuration             **" <<std::endl;
+  std::cout<< "******************************************************************************************" <<std::endl;
+
+  SU<Nc>::HotConfiguration(pRNG,Umu);
+
+  init_plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Initial plaquette "<< init_plaq << std::endl;
+
+  FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,alpha,10000,1.0e-12, 1.0e-12,false);
+
+  plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
+
+  //#########################################################################################
+  if(do_fft_gfix){
+    std::cout<< "******************************************************************************************" <<std::endl;
+    std::cout<< "* Testing Fourier accelerated fixing to Landau gauge with random configuration          **" <<std::endl;
+    std::cout<< "******************************************************************************************" <<std::endl;
+
+    SU<Nc>::HotConfiguration(pRNG,Umu);
+
+    init_plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+    std::cout << " Initial plaquette "<< init_plaq << std::endl;
+
+    FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,alpha,10000,1.0e-12, 1.0e-12,true);
+
+    plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+    std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
+  }
+  //#########################################################################################
+  
+  std::cout<< "*******************************************************************************************" <<std::endl;
+  std::cout<< "* Testing steepest descent fixing to coulomb gauge with random configuration           *" <<std::endl;
+  std::cout<< "*******************************************************************************************" <<std::endl;
+
   Umu=Urnd;
-  FourierAcceleratedGaugeFixer<PeriodicGimplR>::SteepestDescentGaugeFix(Umu,xform2,alpha,10000,1.0e-12, 1.0e-12,true);
+  SU<Nc>::HotConfiguration(pRNG,Umu);
 
-  Utmp=Urnd;
-  SU<Nc>::GaugeTransform(Utmp,xform2);
-  Utmp = Utmp - Umu;
-  std::cout << " Norm Difference of xformed gauge "<< norm2(Utmp) << std::endl;
+  init_plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Initial plaquette "<< init_plaq << std::endl;
+
+  FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,xform3,alpha,10000,1.0e-12, 1.0e-12,false,coulomb_dir);
+
+  plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+  std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
 
 
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Final plaquette "<<plaq << std::endl;
+  //#########################################################################################
+  if(do_fft_gfix){
+    std::cout<< "*******************************************************************************************" <<std::endl;
+    std::cout<< "* Testing Fourier accelerated fixing to coulomb gauge with random configuration           *" <<std::endl;
+    std::cout<< "*******************************************************************************************" <<std::endl;
 
-  std::cout<< "*****************************************************************" <<std::endl;
-  std::cout<< "* Testing non-unit configuration                                *" <<std::endl;
-  std::cout<< "*****************************************************************" <<std::endl;
+    Umu=Urnd;
+    SU<Nc>::HotConfiguration(pRNG,Umu);
 
-  SU<Nc>::HotConfiguration(pRNG,Umu); // Unit gauge
+    init_plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+    std::cout << " Initial plaquette "<< init_plaq << std::endl;
 
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Initial plaquette "<<plaq << std::endl;
+    FourierAcceleratedGaugeFixer<Gimpl>::SteepestDescentGaugeFix(Umu,xform3,alpha,10000,1.0e-12, 1.0e-12,true,coulomb_dir);
 
-  FourierAcceleratedGaugeFixer<PeriodicGimplR>::SteepestDescentGaugeFix(Umu,alpha,10000,1.0e-12, 1.0e-12,true);
+    plaq=WilsonLoops<Gimpl>::avgPlaquette(Umu);
+    std::cout << " Final plaquette "<<plaq << " diff " << plaq - init_plaq << " (expect 0)" << std::endl;
+  }
+}
 
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Final plaquette "<<plaq << std::endl;
+int main (int argc, char ** argv)
+{
+  Grid_init(&argc,&argv);
 
-  std::cout<< "*****************************************************************" <<std::endl;
-  std::cout<< "* Testing Fourier accelerated fixing to coulomb gauge           *" <<std::endl;
-  std::cout<< "*****************************************************************" <<std::endl;
+  double alpha=0.1; //step size
+  std::string gimpl = "periodic";
+  bool do_fft_gfix = true; //test fourier transformed gfix as well as steepest descent
+  for(int i=1;i<argc;i++){
+    std::string sarg(argv[i]);
+    if(sarg == "--gimpl"){
+      assert(i<argc-1 && "--gimpl option requires an argument");
+      gimpl = argv[i+1];
+      if(gimpl != "periodic" && gimpl != "conjugate")
+	assert(0 && "Invalid gimpl");
+      if(gimpl == "conjugate")
+	alpha = 0.025; //default alpha too large for CCBC
+    }else if(sarg == "--no-fft-gfix"){
+      std::cout << "Not doing the Fourier accelerated gauge fixing tests" << std::endl;
+      do_fft_gfix = false;
+    }else if(sarg == "--alpha"){
+      assert(i<argc-1 && "--alpha option requires an argument");
+      std::istringstream ss(argv[i+1]); ss >> alpha;
+    }
+  }
 
-  Umu=Urnd;
-  SU<Nc>::HotConfiguration(pRNG,Umu); // Unit gauge
 
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Initial plaquette "<<plaq << std::endl;
+  if(gimpl == "periodic"){
+    std::cout << GridLogMessage << "Using periodic boundary condition" << std::endl;
+    run<PeriodicGimplR>(alpha, do_fft_gfix);
+  }else{
+    std::vector<int> conjdirs = {1,1,0,0}; //test with 2 conjugate dirs and 2 not
+    std::cout << GridLogMessage << "Using complex conjugate boundary conditions in dimensions ";
+    for(int i=0;i<Nd;i++)
+      if(conjdirs[i])
+	std::cout << i << " ";   
+    std::cout << std::endl;
 
-  FourierAcceleratedGaugeFixer<PeriodicGimplR>::SteepestDescentGaugeFix(Umu,xform3,alpha,10000,1.0e-12, 1.0e-12,true,coulomb_dir);
-
-  std::cout << Umu<<std::endl;
-
-  plaq=WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu);
-  std::cout << " Final plaquette "<<plaq << std::endl;
-
+    ConjugateGimplR::setDirections(conjdirs);
+    run<ConjugateGimplR>(alpha, do_fft_gfix);
+  }
+  
   Grid_finalize();
 }

--- a/tests/core/Test_gamma.cc
+++ b/tests/core/Test_gamma.cc
@@ -228,6 +228,59 @@ void checkGammaL(const Gamma::Algebra a, GridSerialRNG &rng)
   std::cout << std::endl;
 }
 
+void checkChargeConjMatrix(){
+  //Check the properties of the charge conjugation matrix
+  //In the Grid basis C = -\gamma^2 \gamma^4
+  SpinMatrix C = testAlgebra[Gamma::Algebra::MinusGammaY] * testAlgebra[Gamma::Algebra::GammaT];
+  SpinMatrix mC = -C;
+  SpinMatrix one = testAlgebra[Gamma::Algebra::Identity];
+
+  std::cout << "Testing properties of charge conjugation matrix C = -\\gamma^2 \\gamma^4 (in Grid's basis)" << std::endl;
+
+  //C^T = -C
+  SpinMatrix Ct = transpose(C);
+  std::cout << GridLogMessage << "C^T=-C ";
+  test(Ct, mC);
+  std::cout << std::endl;
+
+  //C^\dagger = -C
+  SpinMatrix Cdag = adj(C);
+  std::cout << GridLogMessage << "C^dag=-C ";
+  test(Cdag, mC);
+  std::cout << std::endl;
+
+  //C^* = C
+  SpinMatrix Cstar = conjugate(C);
+  std::cout << GridLogMessage << "C^*=C ";
+  test(Cstar, C);
+  std::cout << std::endl;
+
+  //C^{-1} = -C
+  SpinMatrix CinvC = mC * C;
+  std::cout << GridLogMessage << "C^{-1}=-C ";
+  test(CinvC, one);
+  std::cout << std::endl;
+
+  // C^{-1} \gamma^\mu C = -[\gamma^\mu]^T
+  Gamma::Algebra gmu_a[4] = { Gamma::Algebra::GammaX, Gamma::Algebra::GammaY, Gamma::Algebra::GammaZ, Gamma::Algebra::GammaT };
+  for(int mu=0;mu<4;mu++){
+    SpinMatrix gmu = testAlgebra[gmu_a[mu]];
+    SpinMatrix Cinv_gmu_C = mC * gmu * C;
+    SpinMatrix mgmu_T = -transpose(gmu);
+    std::cout << GridLogMessage << "C^{-1} \\gamma^" << mu << " C = -[\\gamma^" << mu << "]^T ";
+    test(Cinv_gmu_C, mgmu_T);
+    std::cout << std::endl;
+  }
+  
+  //[C, \gamma^5] = 0
+  SpinMatrix Cg5 = C * testAlgebra[Gamma::Algebra::Gamma5];
+  SpinMatrix g5C = testAlgebra[Gamma::Algebra::Gamma5] * C;
+  std::cout << GridLogMessage << "C \\gamma^5 = \\gamma^5 C";
+  test(Cg5, g5C);
+  std::cout << std::endl;
+}
+
+
 int main(int argc, char *argv[])
 {
   Grid_init(&argc,&argv);
@@ -270,6 +323,13 @@ int main(int argc, char *argv[])
   {
     checkGammaL(i, sRNG);
   }
+
+  std::cout << GridLogMessage << "======== Charge conjugation matrix check" << std::endl;
+  checkChargeConjMatrix();
+  std::cout << GridLogMessage << std::endl;
+  
+
+
   
   Grid_finalize();
   


### PR DESCRIPTION
Hi Peter,
Here is round 3 of the import. Changes here are largely focused around correctly supporting non-periodic BCs in pure-gauge operations like gauge fixing, transforming, and computing the topological charge. Also included is functionality to compute the 5LI topological charge (and the cloverleaf energy density). Full change list is below.

Best,
Chris

- To PeriodicBC and ConjugateBC, added a new function "CshiftLink" which performs a boundary-aware C-shift of links or products of links. For the latter, the links crossing the global boundary are complex-conjugated.
- To the gauge implementations, added CshiftLink functions calling into the appropriate operation for the BC in a given direction.
- GaugeTransform, FourierAcceleratedGaugeFixer and WilsonLoops::FieldStrength no longer implicitly assume periodic boundary conditions; instead the shifted link is obtained using CshiftLink and is aware of the gauge implementation.
- Added an assert-check to ensure that the gauge fixing converges within the specified number of steps.
- Added functionality to compute the timeslice averaged plaquette
- Added functionality to compute the 5LI topological charge and timeslice topological charge
- Added a check of the properties of the charge conjugation matrix C=-gamma_2 gamma_4 to Test_gamma
- Fixed const correctness for Replicate
- Modified Test_fft_gfix to support either conjugate or periodic BCs, optionally disabling Fourier-accelerated gauge fixing, and tuning of alpha using cmdline options