### PR TITLE
Photon.h and SHA256 patches

### DIFF
--- a/Grid/qcd/action/gauge/Photon.h
+++ b/Grid/qcd/action/gauge/Photon.h
@@ -49,7 +49,7 @@ NAMESPACE_BEGIN(Grid);
     
     typedef Lattice<SiteLink>  LinkField;
     typedef Lattice<SiteField> Field;
-    typedef Field              ComplexField;
+    typedef LinkField          ComplexField;
   };
   
   typedef QedGImpl<vComplex> QedGImplR;

--- a/Grid/util/Sha.h
+++ b/Grid/util/Sha.h
@@ -27,6 +27,7 @@
     /*  END LEGAL */
 extern "C" {
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 }
 #ifdef USE_IPP
 #include "ipp.h"
@@ -70,10 +71,8 @@ public:
   static inline std::vector<unsigned char> sha256(const void *data,size_t bytes)
   {
     std::vector<unsigned char> hash(SHA256_DIGEST_LENGTH);
-    SHA256_CTX sha256;
-    SHA256_Init  (&sha256);
-    SHA256_Update(&sha256, data,bytes);
-    SHA256_Final (&hash[0], &sha256);
+    auto digest = EVP_get_digestbyname("SHA256");
+    EVP_Digest(data, bytes, &hash[0], NULL, digest, NULL);
     return hash;
   }
   static inline std::vector<int> sha256_seeds(const std::string &s)

--- a/tests/Test_simd.cc
+++ b/tests/Test_simd.cc
@@ -793,6 +793,7 @@ int main (int argc, char ** argv)
     }
     std::cout <<" OK ! "<<std::endl;
 
+#ifdef USE_FP16
     // Double to Half
     std::cout << GridLogMessage<< "Double to half" ;
     precisionChange(&H[0],&D[0],Ndp);
@@ -822,6 +823,7 @@ int main (int argc, char ** argv)
       assert( tmp < 1.0e-3 );
     }
     std::cout <<" OK ! "<<std::endl;
+#endif
 
   }
   Grid_finalize();


### PR DESCRIPTION
This is a collection of a few small changes, addressing issues that I encountered when starting to use Grid recently. I hope this is an appropriate method of suggesting patches.

Summary of changes:
  1. The ComplexField of QedGImpl appeared to be defined wrong and caused compile issues when trying to use U(1) Wilson loop code. Updated its definition from Field to LinkField.
  2. The SHA256 methods used in `Grid/util/Sha.h` are deprecated in OpenSSL 3.0 and cause a lot of warnings. Updated to the suggested API (should be backwards compatible with OpenSSL 1.1.1 as well). The SHA hashes of my seed strings were not affected by the change.
  3. With FP16 disabled, the tests for conversion to half precision fail because the conversion methods rightfully throw `assert(0)` in this case. Added an ifdef guard to these tests so that `make check` passes with this build config.