### PR TITLE
check in GRID_HIP fixes to enable compilation on AMD GPUs for Nc=3

### DIFF
--- a/Grid/qcd/action/fermion/implementation/WilsonFermionImplementation.h
+++ b/Grid/qcd/action/fermion/implementation/WilsonFermionImplementation.h
@@ -600,6 +600,7 @@ void WilsonFermion<Impl>::ContractConservedCurrent(PropagatorField &q_in_1,
                                                    Current curr_type,
                                                    unsigned int mu)
 {
+  #ifndef GRID_HIP
   if(curr_type != Current::Vector)
   {
     std::cout << GridLogError << "Only the conserved vector current is implemented so far." << std::endl;
@@ -641,6 +642,9 @@ void WilsonFermion<Impl>::ContractConservedCurrent(PropagatorField &q_in_1,
 
   q_out-=adj(g5Lg5)*R;
   q_out-=adj(g5Lg5)*gmuR;
+  #else
+    assert(0);
+  #endif
 }
 
 


### PR DESCRIPTION
Included fixes to enable compilation of Grid on AMD GPUs for representations of SU(3) other than the fundamental. 
For Nc=3 this solves issue #343. In particular, the compilation errors appeared when compiling 
WilsonCloverFermionInstantiationWilsonAdjImplF.o, WilsonCloverFermionInstantiationWilsonAdjImplD.o, WilsonFermionInstantiationWilsonAdjImplF.o, WilsonFermionInstantiationWilsonAdjImplD.o .

Changed files 
Grid/qcd/action/fermion/WilsonImpl.h
Grid/qcd/action/fermion/implementation/WilsonFermionImplementation.h
Grid/qcd/action/fermion/implementation/WilsonCloverFermionImplementation.h

--disable-fermion-reps no longer needed in config command
