### PR TITLE
Virtual destructor for LinearOperator

### DIFF
--- a/Grid/algorithms/LinearOperator.h
+++ b/Grid/algorithms/LinearOperator.h
@@ -542,6 +542,7 @@ public:
       (*this)(in[i], out[i]);
     }
   }
+  virtual ~LinearFunction(){};
 };
 
 template<class Field> class IdentityLinearFunction : public LinearFunction<Field> {


### PR DESCRIPTION
This PR implements a trivial virtual destructor for `LinearOperator`. The absence of a virtual destructor is potentially dangerous if `LinearOperator` is used as the base class of a class with a non-trivial destructor.