### PR TITLE
Added GridLogDebug to BuildSurfaceList debug message

### DIFF
--- a/Grid/stencil/Stencil.h
+++ b/Grid/stencil/Stencil.h
@@ -705,7 +705,7 @@ public:
 	}
       }
     }
-    std::cout << "BuildSurfaceList size is "<<surface_list.size()<<std::endl;
+    std::cout << GridLogDebug << "BuildSurfaceList size is "<<surface_list.size()<<std::endl;
   }
   /// Introduce a block structure and switch off comms on boundaries
   void DirichletBlock(const Coordinate &dirichlet_block)


### PR DESCRIPTION
I have recently started seeing lines like
```
BuildSurfaceList size is 110592
```
in my logs. I would propose to only output these when `--log Debug` is selected.