### PR TITLE
Bugfix/irl convergence

### DIFF
--- a/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
+++ b/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
@@ -284,7 +284,6 @@ until convergence
     int iter;
     for(iter = 0; iter<MaxIter; ++iter){
       
-  notYetConverged:
       OrthoTime=0.;
 
       std::cout<< GridLogMessage <<" **********************"<< std::endl;
@@ -422,15 +421,13 @@ until convergence
 
       if ( Nconv < Nstop ) {
 	std::cout << GridLogIRL << "Nconv ("<<Nconv<<") < Nstop ("<<Nstop<<")"<<std::endl;
-	std::cout << GridLogIRL << "starting one more iteration"<<std::endl;
-	iter++;
- 	goto notYetConverged;
+	std::cout << GridLogIRL << "returning Nstop vectors, the last "<< Nstop-Nconv << "of which might meet convergence criterion only approximately" <<std::endl;
       }
       eval=eval2;
       
       //Keep only converged
-      eval.resize(Nconv);// Nstop?
-      evec.resize(Nconv,grid);// Nstop?
+      eval.resize(Nstop);// was Nconv
+      evec.resize(Nstop,grid);// was Nconv
       basisSortInPlace(evec,eval,reverse);
       
     }

--- a/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
+++ b/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
@@ -423,8 +423,8 @@ until convergence
       if ( Nconv < Nstop ) {
 	std::cout << GridLogIRL << "Nconv ("<<Nconv<<") < Nstop ("<<Nstop<<")"<<std::endl;
 	std::cout << GridLogIRL << "starting one more iteration"<<std::endl;
-    iter++;
-    goto notYetConverged;
+	iter++;
+ 	goto notYetConverged;
       }
       eval=eval2;
       

--- a/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
+++ b/Grid/algorithms/iterative/ImplicitlyRestartedLanczos.h
@@ -284,6 +284,7 @@ until convergence
     int iter;
     for(iter = 0; iter<MaxIter; ++iter){
       
+  notYetConverged:
       OrthoTime=0.;
 
       std::cout<< GridLogMessage <<" **********************"<< std::endl;
@@ -419,9 +420,12 @@ until convergence
 	}
       }
 
-      if ( Nconv < Nstop )
+      if ( Nconv < Nstop ) {
 	std::cout << GridLogIRL << "Nconv ("<<Nconv<<") < Nstop ("<<Nstop<<")"<<std::endl;
-
+	std::cout << GridLogIRL << "starting one more iteration"<<std::endl;
+    iter++;
+    goto notYetConverged;
+      }
       eval=eval2;
       
       //Keep only converged


### PR DESCRIPTION
This is a bug I was aware of for a while now, but we had a discussion about this 3 years ago and did think we would never hit it in production. Now it happened (C1M ensemble)

The way the bug is triggered is that the IRL is repetead until Nstop vectors have converged. Then a basis is transformed and the conversion is checked again - if less than Nstop vectors have converged (in our case 199 instead of 200), then a vector of length Nconv is returned. In subsequent steps this might lead to undefined behaviour. (In our case, this led to 'nan' values in the deflation guesser.

I can see the following fixes:

- like attempted here, if less than Nstop vectors have converged after basis rotation, do one more iteration. I am aware that my 'goto' back into a loop is not what we want in production code - we can discuss better ways to implement this
- we could instead abort the program (unsatisfactory, but better than undefined behaviour)
- we could just return Nstop vectors anyway - in all likeliness, if they met the convergence criterion before the basis transformation, it will still be approximately met afterwards.