### PR TITLE
fix HMC for non-fundamental representations

### DIFF
--- a/Grid/qcd/hmc/integrators/Integrator.h
+++ b/Grid/qcd/hmc/integrators/Integrator.h
@@ -237,7 +237,7 @@ public:
 
     for (int level = 0; level < as.size(); ++level) {
       int multiplier = as.at(level).multiplier;
-      ActionLevel<Field> * Level = new ActionLevel<Field>(multiplier);
+      ActionLevel<Field, RepresentationPolicy> * Level = new ActionLevel<Field, RepresentationPolicy>(multiplier);
       Level->push_back(new EmptyAction<Field>); 
       LevelForces.push_back(*Level);
       // does it copy by value or reference??


### PR DESCRIPTION
The change introduced in d1d9827 made HMC code using higher representations fail to compile, as `LevelForces.push_back()` fails due to type mismatches.

This PR adjusts the definition of `LevelForces` to correctly apply the `RepresentationPolicy` of the `Integrator`.