### PR TITLE
fallback to _POSIX_HOST_NAME_MAX if HOST_NAME_MAX is not defined

### DIFF
--- a/Grid/util/Init.cc
+++ b/Grid/util/Init.cc
@@ -77,6 +77,10 @@ feenableexcept (unsigned int excepts)
 }
 #endif
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 NAMESPACE_BEGIN(Grid);
 
 //////////////////////////////////////////////////////

--- a/tests/Test_dwf_mixedcg_prec.cc
+++ b/tests/Test_dwf_mixedcg_prec.cc
@@ -30,6 +30,10 @@ Author: Peter Boyle <paboyle@ph.ed.ac.uk>
 using namespace std;
 using namespace Grid;
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 int main (int argc, char ** argv)
 {
   char hostname[HOST_NAME_MAX+1];


### PR DESCRIPTION
The current head of `develop` fail to compile on e.g. BSD OSs including macOS, because those do not define `HOST_NAME_MAX`. After a bit of research, it looks like `_POSIX_HOST_NAME_MAX` is more widely available, so I defaulted to that if `HOST_NAME_MAX` is not available.