### PR TITLE
Fixed wrong lib for NVTX in configure.ac and updated to nvtx3

### DIFF
--- a/Grid/perfmon/Tracing.h
+++ b/Grid/perfmon/Tracing.h
@@ -3,7 +3,7 @@
 NAMESPACE_BEGIN(Grid);
 
 #ifdef GRID_TRACING_NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 class GridTracer {
 public:
   GridTracer(const char* name) {

--- a/Grid/perfmon/Tracing.h
+++ b/Grid/perfmon/Tracing.h
@@ -3,7 +3,7 @@
 NAMESPACE_BEGIN(Grid);
 
 #ifdef GRID_TRACING_NVTX
-#include <nvtx3/nvToolsExt.h>
+#include <nvToolsExt.h>
 class GridTracer {
 public:
   GridTracer(const char* name) {

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,7 @@ AC_ARG_ENABLE([tracing],
 case ${ac_TRACING} in
     nvtx)
         AC_DEFINE([GRID_TRACING_NVTX],[1],[use NVTX])
+	LIBS="${LIBS} -lnvToolsExt"
 	;;
     roctx)
         AC_DEFINE([GRID_TRACING_ROCTX],[1],[use ROCTX])

--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,6 @@ AC_ARG_ENABLE([tracing],
 case ${ac_TRACING} in
     nvtx)
         AC_DEFINE([GRID_TRACING_NVTX],[1],[use NVTX])
-	LIBS="${LIBS} -lnvToolsExt64_1"
 	;;
     roctx)
         AC_DEFINE([GRID_TRACING_ROCTX],[1],[use ROCTX])


### PR DESCRIPTION
Fixing a bug when trying to build with `--enable-tracing=nvtx` where the linked library had the wrong name, `-lnvToolsExt64_1`.  

The `64_1` extension is only on Windows so is not found on any Linux (and by extension HPC) system.  There are 2 possible fixes to this:

1. Remove the `64_1` from the library name.  This advisable only if support for older versions (<10) of CUDA is required.
2. Remove the linked library all together as from CUDA v10 NVTX is a header-only library and moved to version 3.  This requires also updating the NVTX include in `Grid/perfmon/Tracing.h` to version 3. This is the preferred solution for modern systems and the one in this PR.

Both fix options were tested on a local OpenSUSE workstation only as Tursa is having issues.  Once tested on Tursa and verified the profiler results include NVTX regions, I will change the PR from Draft.