### PR TITLE
Optimise how the CshiftMap table is calculated and copied to the device

### DIFF
--- a/Grid/cshift/Cshift_common.h
+++ b/Grid/cshift/Cshift_common.h
@@ -31,21 +31,73 @@ NAMESPACE_BEGIN(Grid);
 
 extern std::vector<std::pair<int,int> > Cshift_table; 
 extern deviceVector<std::pair<int,int> > Cshift_table_device; 
+extern std::vector<int> Cshift_vector;
+extern deviceVector<int> Cshift_vector_device; 
 
-inline std::pair<int,int> *MapCshiftTable(void)
+// Copy Cshift map object (table or vector) to device
+template<class vobj> 
+inline void MapCshiftCopy(std::vector<vobj> &Cshift_obj, deviceVector<vobj> &Cshift_obj_device)
 {
-  // GPU version
-  uint64_t sz=Cshift_table.size();
-  if (Cshift_table_device.size()!=sz )    {
-    Cshift_table_device.resize(sz);
+  // GPU version only
+  uint64_t sz=Cshift_obj.size();
+  if (Cshift_obj_device.size()!=sz )    {
+    Cshift_obj_device.resize(sz);
   }
-  acceleratorCopyToDevice((void *)&Cshift_table[0],
-			  (void *)&Cshift_table_device[0],
-			  sizeof(Cshift_table[0])*sz);
+  acceleratorCopyToDevice((void *)&Cshift_obj[0],
+			  (void *)&Cshift_obj_device[0],
+			  sizeof(Cshift_obj[0])*sz);
 
-  return &Cshift_table_device[0];
-  // CPU version use identify map
 }
+
+// Copy Cshift map object (table or vector) to device and return pointer to device copy
+template<class vobj> 
+inline vobj *MapCshift(std::vector<vobj> &Cshift_obj, deviceVector<vobj> &Cshift_obj_device)
+{
+  MapCshiftCopy<vobj>(Cshift_obj, Cshift_obj_device);
+
+  return &Cshift_obj_device[0];
+}
+
+// Calculate Cshift_vector
+template<class vobj> 
+void CalculateCshiftVector(Lattice<vobj> &ret, const Lattice<vobj> &rhs, int dimension, int cbmask)
+{
+  GridBase *grid = rhs.Grid();
+
+  if ( !grid->CheckerBoarded(dimension) ) {
+    cbmask=0x3;
+  }
+  
+  int e1=grid->_slice_nblock[dimension]; // clearly loop invariant for icpc
+  int e2=grid->_slice_block[dimension];
+  int stride = grid->_slice_stride[dimension];
+
+  if (Cshift_vector.size() < e1*e2) Cshift_vector.resize(e1*e2); // Let it grow to biggest 
+
+  int ent = 0;
+  if(cbmask == 0x3 ){
+    for(int n=0;n<e1;n++){
+      for(int b=0;b<e2;b++){
+        int o =n*stride+b;
+        Cshift_vector[ent++] = o;
+      }
+    }
+  } else { 
+    for(int n=0;n<e1;n++){
+      for(int b=0;b<e2;b++){
+        int o =n*stride+b;
+        int ocb=1<<ret.Grid()->CheckerBoardFromOindex(o);
+        if ( ocb&cbmask ) {
+          Cshift_vector[ent++] = o;
+        }
+      }
+    }
+  }
+  
+  if (ent < Cshift_vector.size()) Cshift_vector.resize(ent); // trim vector to actual size (relevant for checkerboarded dimensions)
+}
+
+
 ///////////////////////////////////////////////////////////////////
 // Gather for when there is no need to SIMD split 
 ///////////////////////////////////////////////////////////////////
@@ -89,7 +141,7 @@ Gather_plane_simple (const Lattice<vobj> &rhs,deviceVector<vobj> &buffer,int dim
   }
   {
     auto buffer_p = & buffer[0];
-    auto table = MapCshiftTable();
+    auto table = MapCshift<std::pair<int,int> >(Cshift_table, Cshift_table_device);
     autoView(rhs_v , rhs, AcceleratorRead);
     accelerator_for(i,ent,vobj::Nsimd(),{
 	coalescedWrite(buffer_p[table[i].first],coalescedRead(rhs_v[table[i].second]));
@@ -201,7 +253,7 @@ template<class vobj> void Scatter_plane_simple (Lattice<vobj> &rhs,deviceVector<
   
   {
     auto buffer_p = & buffer[0];
-    auto table = MapCshiftTable();
+    auto table = MapCshift<std::pair<int,int> >(Cshift_table, Cshift_table_device);
     autoView( rhs_v, rhs, AcceleratorWrite);
     accelerator_for(i,ent,vobj::Nsimd(),{
 	coalescedWrite(rhs_v[table[i].first],coalescedRead(buffer_p[table[i].second]));
@@ -263,94 +315,32 @@ template<class vobj> void Scatter_plane_merge(Lattice<vobj> &rhs,ExtractPointerA
 
 template<class vobj> void Copy_plane(Lattice<vobj>& lhs,const Lattice<vobj> &rhs, int dimension,int lplane,int rplane,int cbmask)
 {
-  int rd = rhs.Grid()->_rdimensions[dimension];
 
-  if ( !rhs.Grid()->CheckerBoarded(dimension) ) {
-    cbmask=0x3;
-  }
 
   int ro  = rplane*rhs.Grid()->_ostride[dimension]; // base offset for start of plane 
   int lo  = lplane*lhs.Grid()->_ostride[dimension]; // base offset for start of plane 
 
-  int e1=rhs.Grid()->_slice_nblock[dimension]; // clearly loop invariant for icpc
-  int e2=rhs.Grid()->_slice_block[dimension];
-  int stride = rhs.Grid()->_slice_stride[dimension];
+  auto table = &Cshift_vector_device[0];
 
-  if(Cshift_table.size()<e1*e2) Cshift_table.resize(e1*e2); // Let it grow to biggest
-
-  int ent=0;
-
-  if(cbmask == 0x3 ){
-    for(int n=0;n<e1;n++){
-      for(int b=0;b<e2;b++){
-        int o =n*stride+b;
-	Cshift_table[ent++] = std::pair<int,int>(lo+o,ro+o);
-      }
-    }
-  } else { 
-    for(int n=0;n<e1;n++){
-      for(int b=0;b<e2;b++){
-        int o =n*stride+b;
-        int ocb=1<<lhs.Grid()->CheckerBoardFromOindex(o);
-        if ( ocb&cbmask ) {
-	  Cshift_table[ent++] = std::pair<int,int>(lo+o,ro+o);
-	}
-      }
-    }
-  }
-
-  {
-    auto table = MapCshiftTable();
-    autoView(rhs_v , rhs, AcceleratorRead);
-    autoView(lhs_v , lhs, AcceleratorWrite);
-    accelerator_for(i,ent,vobj::Nsimd(),{
-      coalescedWrite(lhs_v[table[i].first],coalescedRead(rhs_v[table[i].second]));
-    });
-  }
+  autoView(rhs_v , rhs, AcceleratorRead);
+  autoView(lhs_v , lhs, AcceleratorWrite);
+  accelerator_for(i,Cshift_vector.size(),vobj::Nsimd(),{
+    coalescedWrite(lhs_v[table[i]+lo],coalescedRead(rhs_v[table[i]+ro]));
+  });
 }
 
 template<class vobj> void Copy_plane_permute(Lattice<vobj>& lhs,const Lattice<vobj> &rhs, int dimension,int lplane,int rplane,int cbmask,int permute_type)
 {
-  int rd = rhs.Grid()->_rdimensions[dimension];
-
-  if ( !rhs.Grid()->CheckerBoarded(dimension) ) {
-    cbmask=0x3;
-  }
 
   int ro  = rplane*rhs.Grid()->_ostride[dimension]; // base offset for start of plane 
   int lo  = lplane*lhs.Grid()->_ostride[dimension]; // base offset for start of plane 
 
-  int e1=rhs.Grid()->_slice_nblock[dimension];
-  int e2=rhs.Grid()->_slice_block [dimension];
-  int stride = rhs.Grid()->_slice_stride[dimension];
-
-  if(Cshift_table.size()<e1*e2) Cshift_table.resize(e1*e2); // Let it grow to biggest
-
-  int ent=0;
-
-  if ( cbmask == 0x3 ) {
-    for(int n=0;n<e1;n++){
-    for(int b=0;b<e2;b++){
-      int o  =n*stride;
-      Cshift_table[ent++] = std::pair<int,int>(lo+o+b,ro+o+b);
-    }}
-  } else {
-    for(int n=0;n<e1;n++){
-    for(int b=0;b<e2;b++){
-      int o  =n*stride;
-      int ocb=1<<lhs.Grid()->CheckerBoardFromOindex(o+b);
-      if ( ocb&cbmask ) Cshift_table[ent++] = std::pair<int,int>(lo+o+b,ro+o+b);
-    }}
-  }
-
-  {
-    auto table = MapCshiftTable();
-    autoView( rhs_v, rhs, AcceleratorRead);
-    autoView( lhs_v, lhs, AcceleratorWrite);
-    accelerator_for(i,ent,1,{
-      permute(lhs_v[table[i].first],rhs_v[table[i].second],permute_type);
+  auto table = &Cshift_vector_device[0];
+  autoView( rhs_v, rhs, AcceleratorRead);
+  autoView( lhs_v, lhs, AcceleratorWrite);
+  accelerator_for(i,Cshift_vector.size(),1,{
+    permute(lhs_v[table[i]+lo],rhs_v[table[i]+ro],permute_type);
     });
-  }
 }
 
 //////////////////////////////////////////////////////
@@ -383,51 +373,54 @@ template<class vobj> void Cshift_local(Lattice<vobj> &ret,const Lattice<vobj> &r
   // Map to always positive shift modulo global full dimension.
   shift = (shift+fd)%fd;
 
+  int cb= (cbmask==0x2)? Odd : Even;
+  int sshift = grid->CheckerBoardShiftForCB(rhs.Checkerboard(),dimension,shift,cb);
+
   // the permute type
   ret.Checkerboard() = grid->CheckerBoardDestination(rhs.Checkerboard(),shift,dimension);
   int permute_dim =grid->PermuteDim(dimension);
   int permute_type=grid->PermuteType(dimension);
   int permute_type_dist;
 
+  // wrap is whether sshift > rd.
+  //  num is sshift mod rd.
+  // 
+  //  shift 7
+  //
+  //  XoXo YcYc 
+  //  oXoX cYcY
+  //  XoXo YcYc
+  //  oXoX cYcY
+  //
+  //  sshift -- 
+  //
+  //  XX YY ; 3
+  //  XX YY ; 0
+  //  XX YY ; 3
+  //  XX YY ; 0
+  //
+  int wrap = sshift/rd; wrap=wrap % ly;
+  int  num = sshift%rd;
+
+  // Calculate Cshift_vector - it's the same for all slices
+  CalculateCshiftVector<vobj>(ret, rhs, dimension, cbmask);
+  // Copy it to the device
+  MapCshiftCopy<int>(Cshift_vector, Cshift_vector_device);
+
   for(int x=0;x<rd;x++){       
 
-    //    int o   = 0;
-    int bo  = x * grid->_ostride[dimension];
-    int cb= (cbmask==0x2)? Odd : Even;
-
-    int sshift = grid->CheckerBoardShiftForCB(rhs.Checkerboard(),dimension,shift,cb);
     int sx     = (x+sshift)%rd;
     
-    // wrap is whether sshift > rd.
-    //  num is sshift mod rd.
-    // 
-    //  shift 7
-    //
-    //  XoXo YcYc 
-    //  oXoX cYcY
-    //  XoXo YcYc
-    //  oXoX cYcY
-    //
-    //  sshift -- 
-    //
-    //  XX YY ; 3
-    //  XX YY ; 0
-    //  XX YY ; 3
-    //  XX YY ; 0
-    //
     int permute_slice=0;
     if(permute_dim){
-      int wrap = sshift/rd; wrap=wrap % ly;
-      int  num = sshift%rd;
-
       if ( x< rd-num ) permute_slice=wrap;
       else permute_slice = (wrap+1)%ly;
 
       if ( (ly>2) && (permute_slice) ) {
-	assert(permute_type & RotateBit);
-	permute_type_dist = permute_type|permute_slice;
+      	assert(permute_type & RotateBit);
+	      permute_type_dist = permute_type|permute_slice;
       } else {
-	permute_type_dist = permute_type;
+	      permute_type_dist = permute_type;
       }
     }
 

--- a/Grid/cshift/Cshift_common.h
+++ b/Grid/cshift/Cshift_common.h
@@ -418,9 +418,9 @@ template<class vobj> void Cshift_local(Lattice<vobj> &ret,const Lattice<vobj> &r
 
       if ( (ly>2) && (permute_slice) ) {
       	assert(permute_type & RotateBit);
-	      permute_type_dist = permute_type|permute_slice;
+	permute_type_dist = permute_type|permute_slice;
       } else {
-	      permute_type_dist = permute_type;
+        permute_type_dist = permute_type;
       }
     }
 

--- a/Grid/cshift/Cshift_mpi.h
+++ b/Grid/cshift/Cshift_mpi.h
@@ -132,6 +132,12 @@ template<class vobj> void Cshift_comms(Lattice<vobj> &ret,const Lattice<vobj> &r
   
   int cb= (cbmask==0x2)? Odd : Even;
   int sshift= rhs.Grid()->CheckerBoardShiftForCB(rhs.Checkerboard(),dimension,shift,cb);
+
+  // Calculate Cshift_vector - it's the same for all slices
+  CalculateCshiftVector<vobj>(ret, rhs, dimension, cbmask);
+  // Copy it to the device
+  MapCshiftCopy<int>(Cshift_vector, Cshift_vector_device);
+  
   RealD tcopy=0.0;
   RealD tgather=0.0;
   RealD tscatter=0.0;

--- a/Grid/cshift/Cshift_table.cc
+++ b/Grid/cshift/Cshift_table.cc
@@ -2,4 +2,6 @@
 NAMESPACE_BEGIN(Grid);
 std::vector<std::pair<int,int> > Cshift_table; 
 deviceVector<std::pair<int,int> > Cshift_table_device; 
+std::vector<int> Cshift_vector;
+deviceVector<int> Cshift_vector_device; 
 NAMESPACE_END(Grid);

--- a/Grid/qcd/smearing/WilsonFlow.h
+++ b/Grid/qcd/smearing/WilsonFlow.h
@@ -207,11 +207,14 @@ std::vector<RealD> WilsonFlowBase<Gimpl>::flowMeasureEnergyDensityCloverleaf(con
 }
 
 template <class Gimpl>
-void WilsonFlowBase<Gimpl>::setDefaultMeasurements(int topq_meas_interval){
-  addMeasurement(1, [](int step, RealD t, const typename Gimpl::GaugeField &U){
+void WilsonFlowBase<Gimpl>::setDefaultMeasurements(int meas_interval){
+  addMeasurement(meas_interval, [](int step, RealD t, const typename Gimpl::GaugeField &U){
       std::cout << GridLogMessage << "[WilsonFlow] Energy density (plaq) : "  << step << "  " << t << "  " << energyDensityPlaquette(t,U) << std::endl;
     });
-  addMeasurement(topq_meas_interval, [](int step, RealD t, const typename Gimpl::GaugeField &U){
+  addMeasurement(meas_interval, [](int step, RealD t, const typename Gimpl::GaugeField &U){
+      std::cout << GridLogMessage << "[WilsonFlow] Energy density (cloverleaf) : "  << step << "  " << t << "  " << energyDensityCloverleaf(t,U) << std::endl;
+    });
+  addMeasurement(meas_interval, [](int step, RealD t, const typename Gimpl::GaugeField &U){
       std::cout << GridLogMessage << "[WilsonFlow] Top. charge           : "  << step << "  " << WilsonLoops<Gimpl>::TopologicalCharge(U) << std::endl;
     });
 }

--- a/HMC/FTHMC2p1f.cc
+++ b/HMC/FTHMC2p1f.cc
@@ -25,13 +25,20 @@ directory
 *************************************************************************************/
 /*  END LEGAL */
 #include <Grid/Grid.h>
+
+#if Nc == 3
 #include <Grid/qcd/smearing/GaugeConfigurationMasked.h>
 #include <Grid/qcd/smearing/JacobianAction.h>
+#endif
 
 using namespace Grid;
 
 int main(int argc, char **argv)
 {
+#if Nc != 3
+#warning FTHMC2p1f will not work for Nc != 3
+  std::cout << "This program will currently only work for Nc == 3." << std::endl;
+#else
   std::cout << std::setprecision(12);
   
   Grid_init(&argc, &argv);
@@ -220,7 +227,6 @@ int main(int argc, char **argv)
   TheHMC.Run(SmearingPolicy); // for smearing
 
   Grid_finalize();
+#endif
 } // main
-
-
 

--- a/HMC/FTHMC2p1f_3GeV.cc
+++ b/HMC/FTHMC2p1f_3GeV.cc
@@ -24,14 +24,22 @@ See the full license in the file "LICENSE" in the top level distribution
 directory
 *************************************************************************************/
 /*  END LEGAL */
+
 #include <Grid/Grid.h>
+
+#if Nc == 3
 #include <Grid/qcd/smearing/GaugeConfigurationMasked.h>
 #include <Grid/qcd/smearing/JacobianAction.h>
+#endif
 
 using namespace Grid;
 
 int main(int argc, char **argv)
 {
+#if Nc != 3
+#warning FTHMC2p1f_3GeV will not work for Nc != 3
+  std::cout << "This program will currently only work for Nc == 3." << std::endl;
+#else
   std::cout << std::setprecision(12);
   
   Grid_init(&argc, &argv);
@@ -220,6 +228,7 @@ int main(int argc, char **argv)
   TheHMC.Run(SmearingPolicy); // for smearing
 
   Grid_finalize();
+#endif
 } // main
 
 

--- a/HMC/HMC2p1f_3GeV.cc
+++ b/HMC/HMC2p1f_3GeV.cc
@@ -25,13 +25,20 @@ directory
 *************************************************************************************/
 /*  END LEGAL */
 #include <Grid/Grid.h>
+
+#if Nc == 3
 #include <Grid/qcd/smearing/GaugeConfigurationMasked.h>
 #include <Grid/qcd/smearing/JacobianAction.h>
+#endif
 
 using namespace Grid;
 
 int main(int argc, char **argv)
 {
+#if Nc != 3
+#warning HMC2p1f_3GeV will not work for Nc != 3
+  std::cout << "This program will currently only work for Nc == 3." << std::endl;
+#else
   std::cout << std::setprecision(12);
   
   Grid_init(&argc, &argv);
@@ -220,6 +227,7 @@ int main(int argc, char **argv)
   TheHMC.Run(SmearingPolicy); // for smearing
 
   Grid_finalize();
+#endif
 } // main
 
 

--- a/tests/smearing/Test_WilsonFlow.cc
+++ b/tests/smearing/Test_WilsonFlow.cc
@@ -33,8 +33,7 @@ namespace Grid{
     GRID_SERIALIZABLE_CLASS_MEMBERS(WFParameters,
             int, steps,
             double, step_size,
-            int, meas_interval,
-            double, maxTau); // for the adaptive algorithm
+            int, meas_interval);
        
 
     template <class ReaderClass >
@@ -86,7 +85,7 @@ int main(int argc, char **argv) {
   WFParameters WFPar(Reader);
   ConfParameters CPar(Reader);
   CheckpointerParameters CPPar(CPar.conf_prefix, CPar.rng_prefix);
-  BinaryHmcCheckpointer<PeriodicGimplR> CPBin(CPPar);
+  NerscHmcCheckpointer<PeriodicGimplR> CPBin(CPPar);
 
   for (int conf = CPar.StartConfiguration; conf <= CPar.EndConfiguration; conf+= CPar.Skip){
 
@@ -96,19 +95,13 @@ int main(int argc, char **argv) {
   std::cout << GridLogMessage << "Initial plaquette: "
     << WilsonLoops<PeriodicGimplR>::avgPlaquette(Umu) << std::endl;
 
-  int t=WFPar.maxTau;
-  WilsonFlowAdaptive<PeriodicGimplR> WF(WFPar.step_size, WFPar.maxTau,
-					1.0e-4,
+  WilsonFlow<PeriodicGimplR> WF(WFPar.step_size, WFPar.steps,
 					WFPar.meas_interval);
 
   WF.smear(Uflow, Umu);
 
   RealD WFlow_plaq = WilsonLoops<PeriodicGimplR>::avgPlaquette(Uflow);
-  RealD WFlow_TC   = WilsonLoops<PeriodicGimplR>::TopologicalCharge(Uflow);
-  RealD WFlow_T0   = WF.energyDensityPlaquette(t,Uflow);
   std::cout << GridLogMessage << "Plaquette          "<< conf << "   " << WFlow_plaq << std::endl;
-  std::cout << GridLogMessage << "T0                 "<< conf << "   " << WFlow_T0 << std::endl;
-  std::cout << GridLogMessage << "TopologicalCharge  "<< conf << "   " << WFlow_TC   << std::endl;
 
   std::cout<< GridLogMessage << " Admissibility check:\n";
   const double sp_adm = 0.067;                // admissible threshold


### PR DESCRIPTION
This PR improves the performance of `Cshift` by optimising the way the `Cshift_table` is calculated and moved to the device:
- The table doesn't need to save an `std::pair<int, int>` per index, since those two ints are the same number + `lo` or `ro`. So an `std::vector<int>` is saved instead.
- The table (now vector) is the same for every slice, therefore it doesn't need to be calculated and copied to the GPU for every slice. So the vector is calculated and copied to the device once before the loop over slices in `Cshift_local` and `Cshift_comms`.
- This new vector is used only for `Copy_plane` and `Copy_plane_permute`. For the rest of the functions (`Gather`s and `Scatter`s) in `Cshift_common.h`, `Cshift_table` remains the same, so some template functions have been added to accommodate both cases while avoiding code duplication.

The improvement in performance varies quite a bit depending on the MPI distribution scheme (see table below), but it is significant nonetheless for cases heavy in gauge calculations.

The PR also contains changes from PR #465  and #471 which were used to asses the performance gains in the WilsonFlow and sp2n test cases.

Four test cases were run on Tursa:
1. tests/sp2n/Test_hmc_Sp_WilsonFundFermionGauge.cc
2. test/hmc/Test_hmc_WilsonFermionGauge.cc
3. HMC/Mobius2p1f.cc
4. tests/smearing/Test_WilsonFlow.cc

with up to 3 different MPI configurations:
- `--mpi 1.1.1.1` (no MPI)
- `--mpi 1.1.1.4` (1 node)
- `--mpi 1.1.2.4` (2 nodes).

Based on the table below, **test case 3 shows no measurable difference** before and after the changes, as expected for a setup with not much contribution from gauge action calculations (and thus not many calls to `Cshift`).
But the other test cases show improvements, from mild ones for test cases 1 and 2, where the runtime is roughly split equally between gauge and fermion actions, to significant **(~18% improvement for the no-MPI case) for test case 4**, which is gauge-dominated.
The above improvements are compounded when the changes in this PR are considered on top of the ones in #473 , giving an improvement of **~32% for test case 4, no MPI** and **~18% for test case 4, single-node MPI**.

This table compares the develop branch at hash https://github.com/paboyle/Grid/commit/3d014864e24f753a84c5bb4966eff12696b0509e , with this branch: 

| Test case | `--grid` | `--mpi` | time `develop` (s) | time `cshift-map-optimise` (s) | improvement (%) |
| - | - | - | - | - | - |
| 1 | 24.24.24.48 | 1.1.1.1 | 5688.42 | 5461.26 | 3.99 |
| 1 | 32.32.32.64 | 1.1.1.4 | 7139.31 | 7026.83 | 1.58 |
| 1 | 32.32.32.64 | 1.1.2.4 | 3735.33 | 3681.24 | 1.45 |
| 2 | 24.24.24.48 | 1.1.1.1 | 1961.20 | 1837.46 | 6.31 |
| 2 | 32.32.32.64 | 1.1.1.4 | 2440.00 | 2372.93 | 2.75 |
| 2 | 32.32.32.64 | 1.1.2.4 | 1314.51 | 1285.40 | 2.21 |
| 3 | 24.24.24.48 | 1.1.1.1 | 14093.66 | 14082.41 | 0.08 |
| 4 | 24.24.24.48 | 1.1.1.1 | 168.96 | 138.59 | 17.98 |
| 4 | 32.32.32.64 | 1.1.1.4 | 225.55 | 210.95 | 6.47 |
| 4 | 32.32.32.64 | 1.1.2.4 | 133.87 | 126.55 | 5.47 |