### PR TITLE
Fix enable-comms=none

### DIFF
--- a/Grid/communicator/Communicator_none.cc
+++ b/Grid/communicator/Communicator_none.cc
@@ -148,9 +148,9 @@ double CartesianCommunicator::StencilSendToRecvFromPrepare(std::vector<CommsRequ
   return 0.0;
 }
 double CartesianCommunicator::StencilSendToRecvFromBegin(std::vector<CommsRequest_t> &list,
-							 void *xmit,
+							 void *xmit, void *xmit_comp,
 							 int xmit_to_rank,int dox,
-							 void *recv,
+							 void *recv, void *recv_comp,
 							 int recv_from_rank,int dor,
 							 int xbytes,int rbytes, int dir)
 {


### PR DESCRIPTION
When `--enable-comms=none` is passed to `configure` compilation breaks.

This is due to an inconsistency of the base `CartesianCommunicator::StencilSendToRecvFromBegin` found in `Grid/communicator/Communicator_base.h` with the implementation in `Grid/communicator/Communicator_none.cc`, namely requiring different arguments.

This small pull request changes the implementation in `Grid/communicator/Communicator_none.cc` to agree with the arguments required in `Grid/communicator/Communicator_base.h`.

Tested on my laptop (Mac M1).
