### PR TITLE
Only compile higher fermion representations for symplectic gauge group when requested via configure flag

### DIFF
--- a/Grid/Makefile.am
+++ b/Grid/Makefile.am
@@ -68,7 +68,9 @@ if BUILD_FERMION_REPS
 endif
 if BUILD_SP
     extra_sources+=$(SP_FERMION_FILES)
+if BUILD_FERMION_REPS
     extra_sources+=$(SP_TWOIND_FERMION_FILES)
+endif
 endif
 
 lib_LIBRARIES = libGrid.a


### PR DESCRIPTION
The current Makefile.am always makes higher representations when symplectic gauge group is chosen during configuration. I.e. if `--enable-Sp` is passed with `--enable-fermion-reps=no`, then the higher representations are still compiled for Sp.

This pull request edits the Makefile.am, not making the higher representations if the `--enable-fermion-reps=no` flag is passed, allowing compilation of symplectic gauge group with fermions only in the fundamental representation.

I have verified both on my laptop (macOS 15.1, on Apple M1) and on the AMD MI300A APU that the code compiles and runs successfully. Namely, if the no flag is passed the higher representations are compiled, otherwise, if the `--enable-fermion-reps=no` flag is passed, the higher representations are not built.