### PR TITLE
Fixed Wilson flow for Nc not equal to 3

### DIFF
--- a/Grid/qcd/action/gauge/GaugeImplTypes.h
+++ b/Grid/qcd/action/gauge/GaugeImplTypes.h
@@ -176,6 +176,8 @@ public:
     Group::ColdConfiguration(pRNG, U);
   }
 
+  static const int num_colours = Group::Dimension;
+
 };
 
 

--- a/Grid/qcd/smearing/WilsonFlow.h
+++ b/Grid/qcd/smearing/WilsonFlow.h
@@ -51,10 +51,16 @@ protected:
 
 public:
 
+//Define the action used to evolve the plaquettes
+//(Lüscher: https://arxiv.org/pdf/1006.4518 eq. 1.4)
+//V'(t) = -g^2 * ( d/dVt S[Vt](g) ) * Vt
+//      = -g^2 * ( d/dVt (1/g^2 * sum_p Re tr{ 1 - Vt(p) } ) ) * Vt
+//      = - d/dVt ( sum_p ( Nc - Re tr Vt(p) ) * Vt
+//      = - d/dVt ( Nc * sum_p ( 1 - Re tr Vt(p)/Nc ) ) * Vt
+//      = - d/dVt SG[Vt](Nc) * Vt
   explicit WilsonFlowBase(unsigned int meas_interval =1) {
     
-    SG = (ActionBase *) new WilsonGaugeAction<Gimpl>(3.0);
-    // WilsonGaugeAction with beta 3.0
+    SG = (ActionBase *) new WilsonGaugeAction<Gimpl>(Gimpl::num_colours);
     setDefaultMeasurements(meas_interval);
   }
 
@@ -149,9 +155,17 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Implementations
 ////////////////////////////////////////////////////////////////////////////////
+
+//Compute t^2 <E(t)> for time from the plaquette form
+//(Lüscher: https://arxiv.org/pdf/1006.4518 eq. 3.1)
+//E(t) = 2 * sum_p Retr{ 1 - Vt(p) } =
+//     = 2 * sum_p ( Nc - Retr Vt(p) ) =
+//     = 2 * Nc * sum_p ( 1 - Retr Vt(p)/Nc )
+//     = 2 * SG[Vt](Nc)
+//We divide by the volume to get an energy density per site, as is convention
 template <class Gimpl>
 RealD WilsonFlowBase<Gimpl>::energyDensityPlaquette(const RealD t, const GaugeField& U){
-  static WilsonGaugeAction<Gimpl> SG(3.0);
+  static WilsonGaugeAction<Gimpl> SG(Gimpl::num_colours);
   return 2.0 * t * t * SG.S(U)/U.Grid()->gSites();
 }
 


### PR DESCRIPTION
There is a bug in the current Wilson flow implementation in Grid when compiled for $N_c \neq 3$ . This is because the code makes an assumption in two places that the Wilson gauge action is always $SG ( 3.0 ) $, when in fact this is $SG( N_c )$. This pull request corrects this behaviour by replacing the 3.0 with the number of colours of the group in the `Gimpl.` To achieve this, it was necessary to also expose this number of colours from the `Gimpl`; currently that template parameter is used within the class but not exposed.

The plots attached to this pull request show the behaviour of the bare energy and energy densities in the following cases:

1. Comparison between HiRep and the former _develop_ branch of Grid for the same ensemble of $Sp(4)$ gauge configurations: the curves associated with the implementation in Grid show that the flows generated by using the plaquette and the cloverleaf prescriptions intersect and tend to diverge as the Wilson flow time grows, which is an unexpected behaviour. Accordingly, we found also a significant discrepancy between HiRep and Grid results.

<img width="1000" height="600" alt="sp4_E_develop_vs_HiRep" src="https://github.com/user-attachments/assets/d72d66f6-5980-4f00-9e63-16fc7ced89f4" />
<img width="1000" height="600" alt="sp4_Ebare_develop_vs_HiRep" src="https://github.com/user-attachments/assets/96365413-3b1c-4ba7-8546-fb53ebc7942d" />

2. Comparison between HiRep and the new _wflow_sp2n_ branch of Grid for the same ensemble of $Sp(4)$ gauge configurations: after changing $\beta=3$ to the right number of colours, we obtained a perfect match between HiRep and Grid implementations. 

<img width="1000" height="600" alt="sp4_E_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/2f0457dd-a605-4d33-9ad9-0b150c866e56" />
<img width="1000" height="600" alt="sp4_Ebare_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/81cbf240-cd99-4cc7-ada7-550cd418a6e0" />

3.  Comparison between the former _develop_ and the new _wflow_sp2n_ branches of Grid for the same ensemble of $SU(3)$ configurations: since our changes do not affect  the case in which the number of colours is equal to 3, the plots in this case do not show any significant difference, and suggest that the two implementations are the same in the case of $SU(3)$. 

<img width="1000" height="600" alt="su3_E_wflow_sp2n_vs_develop" src="https://github.com/user-attachments/assets/b65ca7f7-fa2e-4599-9c62-f7c9827fd1b2" />
<img width="1000" height="600" alt="su3_Ebare_wflow_sp2n_vs_develop" src="https://github.com/user-attachments/assets/03d9438d-8e50-46a1-a01b-4443e9ea74a8" />

4. Comparison between HiRep and the former _develop_ branch of Grid for the same ensemble of $SU(3)$ configurations: also in this case we did not get any discrepancy between the two implementation for the Wilson flow. 

<img width="1000" height="600" alt="su3_E_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/c326d57a-f84f-42a3-9082-2e9b2103928c" />
<img width="1000" height="600" alt="su3_Ebare_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/395b508b-2b0b-4bdc-abdd-add0a4023c46" />


