### PR TITLE
Fix namespace for GridAbort when comms=none

### DIFF
--- a/Grid/communicator/Communicator_none.cc
+++ b/Grid/communicator/Communicator_none.cc
@@ -27,6 +27,8 @@ Author: Peter Boyle <paboyle@ph.ed.ac.uk>
 /*  END LEGAL */
 #include <Grid/GridCore.h>
 
+void GridAbort(void) { abort(); }
+
 NAMESPACE_BEGIN(Grid);
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -34,7 +36,6 @@ NAMESPACE_BEGIN(Grid);
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 Grid_MPI_Comm       CartesianCommunicator::communicator_world;
 
-void GridAbort(void) { abort(); }
 
 void CartesianCommunicator::Init(int *argc, char *** arv)
 {


### PR DESCRIPTION
Currently `--enable-comms=none` will not allow Grid to compile due to a missing symbol for `GridAbort()`.

In `Grid/GridStd.h`, `GridAbort()` is declared in the global scope. 
For `--enable-comms=mpi3` the definition in `Grid/communicator/Communicator_mpi3.cc` is also at the global scope.
However the `--enable-comms=none` version in `Grid/communicator/Communicator_none.cc` is defined within the `Grid` namespace.

This pull request simply edits scope of the `--enable-comms=none` function definition from `Grid::GridAbort()` to `::GridAbort()`.