### PR TITLE
Define Sp4 ProjectOnGeneralGroup for generic vtype

### DIFF
--- a/Grid/qcd/utils/Sp2n.impl.h
+++ b/Grid/qcd/utils/Sp2n.impl.h
@@ -254,9 +254,9 @@ static void testGenerators(GroupName::Sp) {
   }
 }
 
-template <int N>
-static Lattice<iScalar<iScalar<iMatrix<vComplexD, N> > > >
-ProjectOnGeneralGroup(const Lattice<iScalar<iScalar<iMatrix<vComplexD, N> > > > &Umu, GroupName::Sp) {
+template <class vtype, int N>
+static Lattice<iScalar<iScalar<iMatrix<vtype, N> > > >
+ProjectOnGeneralGroup(const Lattice<iScalar<iScalar<iMatrix<vtype, N> > > > &Umu, GroupName::Sp) {
   return ProjectOnSpGroup(Umu);
 }
 


### PR DESCRIPTION
The Sp(4) implementation of `ProjectOnGeneralGroup` currently cannot be instantiated for `vComplexF` due to being hardcoded to use a `vComplexD` SIMD type.

This pull request permits a template instantiation for e.g. single-precision routines.
