### PR TITLE
Add ET support for Lattice spin- and colour-traces

### DIFF
--- a/Grid/qcd/QCD.h
+++ b/Grid/qcd/QCD.h
@@ -596,16 +596,32 @@ template<int Index,class vobj> inline vobj transposeColour(const vobj &lhs){
 //////////////////////////////////////////
 // Trace lattice and non-lattice
 //////////////////////////////////////////
+#define GRID_UNOP(name)   name
+#define GRID_DEF_UNOP(op, name)						\
+  template <typename T1, typename std::enable_if<is_lattice<T1>::value||is_lattice_expr<T1>::value,T1>::type * = nullptr> \
+  inline auto op(const T1 &arg) ->decltype(LatticeUnaryExpression<GRID_UNOP(name),T1>(GRID_UNOP(name)(), arg)) \
+  {									\
+    return     LatticeUnaryExpression<GRID_UNOP(name),T1>(GRID_UNOP(name)(), arg); \
+  }
+
 template<int Index,class vobj>
 inline auto traceSpin(const Lattice<vobj> &lhs) -> Lattice<decltype(traceIndex<SpinIndex>(vobj()))>
 {
   return traceIndex<SpinIndex>(lhs);
 }
+
+GridUnopClass(UnaryTraceSpin, traceIndex<SpinIndex>(a));
+GRID_DEF_UNOP(traceSpin, UnaryTraceSpin);
+
 template<int Index,class vobj>
 inline auto traceColour(const Lattice<vobj> &lhs) -> Lattice<decltype(traceIndex<ColourIndex>(vobj()))>
 {
   return traceIndex<ColourIndex>(lhs);
 }
+
+GridUnopClass(UnaryTraceColour, traceIndex<ColourIndex>(a));
+GRID_DEF_UNOP(traceColour, UnaryTraceColour);
+
 template<int Index,class vobj>
 inline auto traceSpin(const vobj &lhs) -> Lattice<decltype(traceIndex<SpinIndex>(lhs))>
 {
@@ -617,6 +633,8 @@ inline auto traceColour(const vobj &lhs) -> Lattice<decltype(traceIndex<ColourIn
   return traceIndex<ColourIndex>(lhs);
 }
 
+#undef GRID_UNOP
+#undef GRID_DEF_UNOP
 //////////////////////////////////////////
 // Current types
 //////////////////////////////////////////


### PR DESCRIPTION
Currently, the functions `TraceColour` and `TraceSpin`, as well as the more generic `TraceIndex` ( `Grid/lattice/Lattice_trace.h`) are available for tracing over internal indices of lattice objects. However, these functions cannot take an expression template as an argument, requiring them to be called as e.g. `TraceIndex<ColourIndex>(closure(a*b))` or for the expression to be assigned to a temporary first, forcing the full expression evaluation before the trace is performed.

This pull request adds expression-template-compatible `traceColour` and `traceSpin` overloads in the same spirit as `trace`, removing the need for a `closure()` and reducing the cost of a trace over individual indices. This is currently being used to obtain performance gains in a contraction-heavy in-development workflow.

This is a minimally-intrusive implementation that may not be ideal, in large part due to replicating the macros from `Grid/lattice/Lattice_ET.h`. To avoid this the macro `#undef`s at the bottom of `Grid/lattice/Lattice_ET.h` could be removed.
These operators can't live inside `Grid/lattice/Lattice_ET.h` because `SpinIndex` and `ColourIndex` are defined in `Grid/qcd/QCD.h`, and implementing a `traceIndex` op would require additional macro definitions to account for the `Index` template parameter -- which might be the better way to achieve this.

I will update the pull request with production GPU benchmarks in the next few days.
