### PR TITLE
Fix alignment on StencilEntry struct for HIP

### DIFF
--- a/Grid/stencil/Stencil.h
+++ b/Grid/stencil/Stencil.h
@@ -82,7 +82,7 @@ void DslashLogPartial(void);
 void DslashLogDirichlet(void);
 
 struct StencilEntry {
-#ifdef GRID_CUDA
+#if defined(GRID_CUDA) || defined(GRID_HIP)
   uint64_t _byte_offset;       // 8 bytes
   uint32_t _offset;            // 4 bytes
 #else


### PR DESCRIPTION
CUDA neatly aligns the StencilEntry struct to 16-bytes by storing the _offset field in 4 bytes instead of 8.
Bringing the same change to HIP yields around 5% better performance on MI355X-class GPUs.